### PR TITLE
fix: bigfont vertical alignment for punctuation and top-aligned glyphs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - '.'
+
 allowBuilds:
   esbuild: true

--- a/src/__tests__/font.test.ts
+++ b/src/__tests__/font.test.ts
@@ -1,0 +1,59 @@
+import { ShxFont } from '../font';
+import { ShxFontData, ShxFontType } from '../fontData';
+
+function createBigFontData(shapes: Record<number, Uint8Array>): ShxFontData {
+  return {
+    header: {
+      fontType: ShxFontType.BIGFONT,
+      fileHeader: 'AutoCAD-86 bigfont V1.0',
+      fileVersion: '1.0',
+    },
+    content: {
+      data: shapes,
+      info: 'test',
+      orientation: 'horizontal',
+      baseUp: 7,
+      baseDown: 1,
+      height: 8,
+      width: 8,
+      isExtended: false,
+    },
+  };
+}
+
+describe('ShxFont', () => {
+  describe('getCharShape bigfont alignment', () => {
+    // Horizontal line along the baseline: pen down, draw 8 units east, pen up, end.
+    const baselineShape = new Uint8Array([0x01, 0x80, 0x02, 0x00]);
+    // Horizontal line near the top of the cell: move to (0, 7), pen down, draw east, pen up, end.
+    const topAlignedShape = new Uint8Array([0x08, 0x00, 0x07, 0x01, 0x80, 0x02, 0x00]);
+
+    const font = new ShxFont(
+      createBigFontData({
+        1: baselineShape,
+        2: topAlignedShape,
+      })
+    );
+
+    afterAll(() => {
+      font.release();
+    });
+
+    it('normalizes baseline-aligned bigfont glyphs to the origin', () => {
+      const size = 16;
+      const shape = font.getCharShape(1, size);
+
+      expect(shape).toBeDefined();
+      expect(shape!.bbox.minX).toBe(0);
+      expect(shape!.bbox.minY).toBe(0);
+    });
+
+    it('preserves vertical position for top-aligned bigfont glyphs', () => {
+      const size = 16;
+      const shape = font.getCharShape(2, size);
+
+      expect(shape).toBeDefined();
+      expect(shape!.bbox.minY).toBeCloseTo(14);
+    });
+  });
+});

--- a/src/font.ts
+++ b/src/font.ts
@@ -56,7 +56,11 @@ export class ShxFont {
   public getCharShape(code: number, size: number) {
     let shape = this.shapeParser.getCharShape(code, size);
     if (shape && this.fontData.header.fontType === ShxFontType.BIGFONT) {
-      shape = shape.normalizeToOrigin();
+      // Only normalize baseline-aligned glyphs. Top/center-aligned characters
+      // (e.g. "一", quotation marks) must keep their original vertical position.
+      if (shape.bbox.minY <= size * 0.2) {
+        shape = shape.normalizeToOrigin();
+      }
     }
     return shape;
   }


### PR DESCRIPTION
## Summary
- Fix bigfont misalignment where punctuation and top/center-aligned characters (e.g. 一, quotation marks) were shifted to the baseline
- Only call `normalizeToOrigin()` when `bbox.minY <= size * 0.2`, preserving vertical position for glyphs that are not baseline-aligned
- Add unit tests covering baseline-aligned and top-aligned bigfont glyphs

Fixes #1

## Test plan
- [x] `npm test` — all 42 tests pass
- [x] `npm run lint` — no errors
- [ ] Load a bigfont SHX file in the demo app and verify punctuation/top-aligned characters render at the correct vertical position

Made with [Cursor](https://cursor.com)