### PR TITLE
Add npm publish automation to CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,12 +3,15 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -17,17 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v2
+        uses: actions/checkout@v6
         with:
-          version: 9
-      
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v6
+
       # Cache node_modules
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
+          registry-url: https://registry.npmjs.org
        
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -41,20 +45,32 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+      - name: Publish package to npm
+        if: startsWith(github.ref, 'refs/tags/')
+        run: pnpm publish:package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+
   deploy:
     needs: [ci]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 9
-      
+      - uses: pnpm/action-setup@v6
+
       # Cache node_modules
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -66,13 +82,13 @@ jobs:
         run: pnpm example
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: './examples/'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json}\"",
     "lint": "eslint \"src/**/*.{ts,tsx,js,jsx}\"",
-    "lint:fix": "eslint \"src/**/*.{ts,tsx,js,jsx}\" --fix"
+    "lint:fix": "eslint \"src/**/*.{ts,tsx,js,jsx}\" --fix",
+    "release": "node tools/release.mjs",
+    "publish:package": "pnpm publish --no-git-checks --access public"
   },
   "keywords": [
     "autocad",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "bugs": {
     "url": "https://github.com/mlightcad/shx-parser/-/issues"
   },
+  "packageManager": "pnpm@10.33.4",
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@types/jest": "^29.5.12",

--- a/tools/release.mjs
+++ b/tools/release.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+function run(cmd) {
+  return execSync(cmd, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function fail(msg) {
+  console.error(`❌ ${msg}`);
+  process.exit(1);
+}
+
+/**
+ * Parse vX.Y.Z
+ */
+function parseVersion(tag) {
+  const m = tag.match(/^v(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return {
+    major: Number(m[1]),
+    minor: Number(m[2]),
+    patch: Number(m[3]),
+  };
+}
+
+/**
+ * Find latest vX.Y.Z tag (sorted by semver, not by time)
+ */
+function findLatestTag() {
+  const output = run('git tag --list "v*.*.*"');
+  if (!output) return null;
+
+  const tags = output
+    .split('\n')
+    .map(t => ({ tag: t, v: parseVersion(t) }))
+    .filter(t => t.v !== null);
+
+  if (tags.length === 0) return null;
+
+  tags.sort((a, b) => {
+    if (a.v.major !== b.v.major) return b.v.major - a.v.major;
+    if (a.v.minor !== b.v.minor) return b.v.minor - a.v.minor;
+    return b.v.patch - a.v.patch;
+  });
+
+  return tags[0].tag;
+}
+
+/**
+ * Main
+ */
+let version = process.argv[2];
+
+if (!version) {
+  const latestTag = findLatestTag();
+  if (!latestTag) {
+    fail('No existing vX.Y.Z tag found, please specify a version explicitly.');
+  }
+
+  const v = parseVersion(latestTag);
+  version = `${v.major}.${v.minor}.${v.patch + 1}`;
+
+  console.log(`ℹ️  No version provided, auto-incrementing patch: ${latestTag} → v${version}`);
+}
+
+if (!/^\d+\.\d+\.\d+$/.test(version)) {
+  fail(`Invalid version "${version}". Expected format: X.Y.Z`);
+}
+
+const tag = `v${version}`;
+
+/**
+ * Safety checks
+ */
+try {
+  run(`git rev-parse --verify refs/tags/${tag}`);
+  fail(`Tag ${tag} already exists.`);
+} catch {
+  // tag does not exist → OK
+}
+
+try {
+  const branch = run('git branch --show-current');
+  if (branch !== 'main') {
+    fail(`Current branch is "${branch}". Please release from "main".`);
+  }
+} catch {
+  // non-fatal
+}
+
+const status = run('git status --porcelain');
+if (status) {
+  fail('Working tree is not clean. Please commit or stash changes.');
+}
+
+/**
+ * Create & push annotated tag
+ */
+console.log(`🚀 Creating tag ${tag}`);
+
+run(`git tag -a ${tag} -m "release: release ${tag}"`);
+run(`git push origin ${tag}`);
+
+console.log(`✅ Release tag ${tag} pushed successfully`);


### PR DESCRIPTION
## Summary

- Add tag-triggered npm publish step to CI (on \*\ tags), matching the mtext-renderer workflow
- Create GitHub Release automatically when a version tag is pushed
- Add \	ools/release.mjs\ and \elease\ / \publish:package\ npm scripts for local semver tagging
- Upgrade GitHub Actions to v6 and grant \contents: write\ for release creation

## Test plan

- [ ] Verify CI passes on this PR (lint, build, test)
- [ ] Confirm \NPM_TOKEN\ secret is configured in the repository
- [ ] After merge: bump \package.json\ version, run \pnpm release\, and verify npm publish + GitHub Release on tag push

Made with [Cursor](https://cursor.com)