### PR TITLE
fix: improve bigfont normalization and unifont subshape handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/shx-parser",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "A TypeScript library for parsing AutoCAD SHX font files",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/src/font.ts
+++ b/src/font.ts
@@ -56,9 +56,10 @@ export class ShxFont {
   public getCharShape(code: number, size: number) {
     let shape = this.shapeParser.getCharShape(code, size);
     if (shape && this.fontData.header.fontType === ShxFontType.BIGFONT) {
-      // Only normalize baseline-aligned glyphs. Top/center-aligned characters
-      // (e.g. "一", quotation marks) must keep their original vertical position.
-      if (shape.bbox.minY <= size * 0.2) {
+      // Normalize baseline-aligned and mid-cell body glyphs to the origin.
+      // Top/center punctuation (e.g. “一”, quotation marks) sit in the upper
+      // half of the cell and must keep their vertical position.
+      if (shape.bbox.minY <= size * 0.5) {
         shape = shape.normalizeToOrigin();
       }
     }

--- a/src/shapeParser.ts
+++ b/src/shapeParser.ts
@@ -463,9 +463,7 @@ export class ShxShapeParser {
           origin,
           inheritParentPen
         );
-        const merged =
-          shape?.polylines.some(line => line.length >= 2) ?? false;
-        if (merged) {
+        if (shape?.polylines.some(line => line.length >= 2)) {
           state.polylines.push(...shape.polylines.slice());
           if (shape.lastPoint) {
             state.currentPoint = shape.lastPoint.clone();

--- a/src/shapeParser.ts
+++ b/src/shapeParser.ts
@@ -166,6 +166,10 @@ export class ShxShapeParser {
       sp,
       isPenDown,
       scale: 1,
+      // Only flush a pen-down polyline on shape end when parsing a unifont
+      // subshape with inherited pen (amgdt %%132). Global flush regresses bigfont
+      // subshape caches (e.g. gbcbig.shx CJK glyphs).
+      flushEndPolyline: options.initialPenDown ?? false,
     };
 
     for (let i = 0; i < data.length; i++) {
@@ -201,13 +205,14 @@ export class ShxShapeParser {
       sp: Point[];
       isPenDown: boolean;
       scale: number;
+      flushEndPolyline?: boolean;
     }
   ): number {
     let i = index;
 
     switch (command) {
       case 0: // End of shape definition
-        if (state.currentPolyline.length > 1) {
+        if (state.flushEndPolyline && state.currentPolyline.length > 1) {
           state.polylines.push(state.currentPolyline.slice());
         }
         state.currentPolyline = [];
@@ -264,8 +269,9 @@ export class ShxShapeParser {
         break;
       case 14: // Vertical-only command
         // https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-06832147-16BE-4A66-A6D0-3ADF98DC8228
-        // Horizontal fonts skip the next command. Vertical fonts (e.g. amgdt.shx) execute it.
-        // Reverted to skip-only for now — executing the next command regresses other amgdt glyphs.
+        // Horizontal-orientation fonts skip the next command. Vertical-orientation
+        // fonts (e.g. amgdt.shx) normally execute it, but doing so globally regresses
+        // many amgdt glyphs; keep skip-only until shape-specific handling exists.
         i = this.skipCode(data, ++i);
         break;
     }
@@ -448,23 +454,40 @@ export class ShxShapeParser {
     }
 
     if (subCode !== 0) {
-      shape = this.getScaledSubshapeAtInsertPoint(
-        subCode,
-        width,
-        height,
-        origin,
-        state.isPenDown
-      );
-      if (shape?.polylines.some(line => line.length >= 2)) {
-        state.polylines.push(...shape.polylines.slice());
-        if (shape.lastPoint) {
-          state.currentPoint = shape.lastPoint.clone();
+      if (this.fontData.header.fontType === ShxFontType.UNIFONT) {
+        const inheritParentPen = state.isPenDown;
+        shape = this.getScaledSubshapeAtInsertPoint(
+          subCode,
+          width,
+          height,
+          origin,
+          inheritParentPen
+        );
+        const merged =
+          shape?.polylines.some(line => line.length >= 2) ?? false;
+        if (merged) {
+          state.polylines.push(...shape.polylines.slice());
+          if (shape.lastPoint) {
+            state.currentPoint = shape.lastPoint.clone();
+          }
+          state.currentPolyline = [];
+          if (state.isPenDown) {
+            state.currentPolyline.push(state.currentPoint.clone());
+          }
         }
-        // Resume parent shape drawing after a successful subshape insert.
+        // Empty unifont subshape (amgdt %%132): keep pen state and currentPolyline.
+      } else {
+        // Original SHAPES / BIGFONT behavior — do not gate on polyline length.
+        shape = this.getScaledSubshapeAtInsertPoint(
+          subCode,
+          width,
+          height,
+          origin
+        );
+        if (shape) {
+          state.polylines.push(...shape.polylines.slice());
+        }
         state.currentPolyline = [];
-        if (state.isPenDown) {
-          state.currentPolyline.push(state.currentPoint.clone());
-        }
       }
     }
 


### PR DESCRIPTION
## Summary
- Expand BIGFONT baseline normalization threshold from `0.2 * size` to `0.5 * size` so mid-cell body glyphs align correctly while top/center punctuation (e.g. “一”, quotation marks) keep their vertical position.
- Scope unifont subshape end-of-shape polyline flush to shapes with inherited pen state, fixing amgdt GDT glyphs (e.g. %%132) without regressing bigfont subshape caches (e.g. gbcbig.shx CJK glyphs).
- Split unifont vs SHAPES/BIGFONT subshape merge logic so bigfont subshapes retain original behavior.
- Bump version to 1.3.4.

## Test plan
- [ ] Verify bigfont CJK glyphs (gbcbig.shx) render correctly after subshape inserts
- [ ] Verify amgdt GDT symbols (e.g. %%132) render with correct pen state
- [ ] Confirm top/center-aligned bigfont punctuation is not vertically shifted
- [ ] Run existing test suite