### PR TITLE
feat: parse and expose shape names from shape/unifont fonts

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -108,6 +108,11 @@ async function main() {
     console.log('Base Down:', fontData.content.baseDown);
     console.log('Number of shapes:', Object.keys(fontData.content.data).length);
     console.log('Available codes:', Object.keys(fontData.content.data).join(', '));
+    if (fontData.content.names) {
+      console.log('Named shapes:', Object.entries(fontData.content.names)
+        .map(([name, code]) => `${name}=${code}`)
+        .join(', '));
+    }
     console.log('----------------\n');
 
     // Example: Generate SVG for a text string

--- a/examples/index.html
+++ b/examples/index.html
@@ -248,13 +248,15 @@
                 <div id="fileVersion" class="font-info-value"></div>
                 <div class="font-info-label">Number of Characters:</div>
                 <div id="charCount" class="font-info-value"></div>
+                <div class="font-info-label" id="namedShapeLabel" style="display: none;">Named Shapes:</div>
+                <div id="namedShapeCount" class="font-info-value" style="display: none;"></div>
                 <div class="font-info-label">Font Additional Info:</div>
                 <div id="fontAdditionalInfo" class="font-info-value"></div>
             </div>
         </div>
         
         <div class="search-container">
-            <input type="text" id="codeSearch" class="search-input" placeholder="Search by code (e.g. 65 for 'A' or 0x41)" />
+            <input type="text" id="codeSearch" class="search-input" placeholder="Search by code or shape name (e.g. 65, 0x41, GRS)" />
             <button type="button" id="searchClear" class="search-clear" aria-label="Clear search">&times;</button>
         </div>
 
@@ -431,6 +433,14 @@
                 document.getElementById('fontType').textContent = header.fontType;
                 document.getElementById('fileVersion').textContent = header.fileVersion;
                 document.getElementById('charCount').textContent = Object.keys(content.data).length;
+
+                const namedShapeLabel = document.getElementById('namedShapeLabel');
+                const namedShapeCount = document.getElementById('namedShapeCount');
+                const namedCount = content.names ? Object.keys(content.names).length : 0;
+                namedShapeLabel.style.display = namedCount > 0 ? '' : 'none';
+                namedShapeCount.style.display = namedCount > 0 ? '' : 'none';
+                namedShapeCount.textContent = namedCount;
+
                 document.getElementById('fontAdditionalInfo').textContent = content.info
             }
 
@@ -456,26 +466,37 @@
                 const info = document.createElement('div');
                 info.className = 'character-info';
                 info.dataset.code = code;
-                this.updateCellFormat(info, code);
+                const shapeName = this.font.getShapeName(parseInt(code));
+                if (shapeName) {
+                    info.dataset.name = shapeName;
+                }
+                this.updateCellFormat(info, code, shapeName);
                 cell.appendChild(info);
 
                 // Add click handler to show modal
-                cell.addEventListener('click', () => this.showModal(code, shape));
+                cell.addEventListener('click', () => this.showModal(code, shape, shapeName));
 
                 return cell;
             }
 
-            updateCellFormat(infoElement, code) {
+            formatCode(code) {
                 const numCode = parseInt(code);
-                infoElement.textContent = this.formatToggle.checked ? 
-                    `Code: 0x${numCode.toString(16).toUpperCase()}` :
-                    `Code: ${code}`;
+                return this.formatToggle.checked ?
+                    `0x${numCode.toString(16).toUpperCase()}` :
+                    `${code}`;
+            }
+
+            updateCellFormat(infoElement, code, shapeName) {
+                const codeText = this.formatCode(code);
+                infoElement.textContent = shapeName ?
+                    `${shapeName} (${codeText})` :
+                    `Code: ${codeText}`;
             }
 
             updateCodeFormat() {
                 this.allCharacterCells.forEach((cell, code) => {
                     const info = cell.querySelector('.character-info');
-                    this.updateCellFormat(info, code);
+                    this.updateCellFormat(info, code, info.dataset.name);
                 });
             }
 
@@ -502,6 +523,11 @@
                     if (searchValue === '') {
                         cell.style.display = ''; // Show all when search is empty
                     } else {
+                        const info = cell.querySelector('.character-info');
+                        const shapeName = info?.dataset.name;
+                        const searchLower = searchValue.toLowerCase();
+                        const nameMatch = shapeName && shapeName.toLowerCase().includes(searchLower);
+
                         let searchCode;
                         if (searchValue.toLowerCase().startsWith('0x')) {
                             // Handle hexadecimal input
@@ -511,7 +537,9 @@
                             searchCode = parseInt(searchValue).toString();
                         }
 
-                        if (!isNaN(parseInt(searchCode))) {
+                        if (nameMatch) {
+                            cell.style.display = '';
+                        } else if (!isNaN(parseInt(searchCode))) {
                             cell.style.display = code === searchCode ? '' : 'none';
                         } else if (!isBigFont) {
                             // For regular fonts, convert to Unicode
@@ -555,7 +583,7 @@
                 });
             }
 
-            showModal(code, shape) {
+            showModal(code, shape, shapeName) {
                 this.modalShape.innerHTML = '';
 
                 // Get SVG string with auto-fit enabled
@@ -571,10 +599,10 @@
                 this.modalShape.appendChild(svg);
                 
                 // Update modal character info
-                const numCode = parseInt(code);
-                this.modalCharacterInfo.textContent = this.formatToggle.checked ? 
-                    `Character Code: 0x${numCode.toString(16).toUpperCase()}` :
-                    `Character Code: ${code}`;
+                const codeText = this.formatCode(code);
+                this.modalCharacterInfo.textContent = shapeName ?
+                    `Shape: ${shapeName} (Code: ${codeText})` :
+                    `Character Code: ${codeText}`;
 
                 // Show modal
                 this.modal.style.display = 'flex';

--- a/src/__tests__/shapeNames.test.ts
+++ b/src/__tests__/shapeNames.test.ts
@@ -1,0 +1,122 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { splitShapeNameAndBytecode } from '../contentParser';
+import { ShxFont } from '../font';
+import { ShxFontData, ShxFontType } from '../fontData';
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
+
+function encodeNamedShape(name: string, bytecode: Uint8Array): Uint8Array {
+  const nameBytes = new TextEncoder().encode(name);
+  const raw = new Uint8Array(nameBytes.length + 1 + bytecode.length);
+  raw.set(nameBytes, 0);
+  raw[nameBytes.length] = 0;
+  raw.set(bytecode, nameBytes.length + 1);
+  return raw;
+}
+
+function createShapeFontFromRaw(rawShapes: Record<number, Uint8Array>): ShxFont {
+  const data: Record<number, Uint8Array> = {};
+  const names: Record<string, number> = {};
+
+  for (const [codeKey, bytes] of Object.entries(rawShapes)) {
+    const code = Number(codeKey);
+    const { name, bytecode } = splitShapeNameAndBytecode(bytes);
+    data[code] = bytecode;
+    if (name) {
+      names[name] = code;
+    }
+  }
+
+  const fontData: ShxFontData = {
+    header: {
+      fontType: ShxFontType.SHAPES,
+      fileHeader: 'AutoCAD-86 shapes V1.0',
+      fileVersion: '1.0',
+    },
+    content: {
+      data,
+      names,
+      info: '',
+      orientation: 'horizontal',
+      baseUp: 8,
+      baseDown: 2,
+      height: 10,
+      width: 10,
+      isExtended: false,
+    },
+  };
+
+  return new ShxFont(fontData);
+}
+
+async function loadG13f12d(): Promise<ShxFont> {
+  try {
+    const response = await fetch(FONT_BASE + 'g13f12d.shx');
+    if (!response.ok) {
+      throw new Error(`fetch failed: ${response.status}`);
+    }
+    return new ShxFont(await response.arrayBuffer());
+  } catch {
+    const localPath = join(process.cwd(), 'examples', 'fonts', 'g13f12d.shx');
+    const data = await readFile(localPath);
+    return new ShxFont(data.buffer);
+  }
+}
+
+describe('shape name parsing', () => {
+  it('splits a null-terminated shape name from bytecode', () => {
+    const bytecode = new Uint8Array([0x01, 0x80, 0x02, 0x00]);
+    const raw = encodeNamedShape('GRS', bytecode);
+
+    expect(splitShapeNameAndBytecode(raw)).toEqual({
+      name: 'GRS',
+      bytecode,
+    });
+  });
+
+  it('treats a leading null byte as an empty shape name', () => {
+    const bytecode = new Uint8Array([0x02, 0x14, 0x03, 0x00]);
+    const raw = new Uint8Array([0x00, ...bytecode]);
+
+    expect(splitShapeNameAndBytecode(raw)).toEqual({
+      name: null,
+      bytecode,
+    });
+  });
+
+  it('looks up named shapes case-insensitively', () => {
+    const font = createShapeFontFromRaw({
+      135: encodeNamedShape('GRS', new Uint8Array([0x01, 0x80, 0x02, 0x00])),
+    });
+
+    try {
+      expect(font.hasShape('GRS')).toBe(true);
+      expect(font.hasShape('grs')).toBe(true);
+      expect(font.getShapeCode('grs')).toBe(135);
+      expect(font.getShapeName(135)).toBe('GRS');
+
+      const shape = font.getShapeByName('grs', 10);
+      expect(shape).toBeDefined();
+      expect(shape!.polylines.length).toBeGreaterThan(0);
+    } finally {
+      font.release();
+    }
+  });
+
+  it('parses named shapes from a real compiled shape font', async () => {
+    const font = await loadG13f12d();
+    try {
+      expect(font.hasShape('!')).toBe(true);
+      expect(font.getShapeCode('!')).toBe(33);
+
+      const byCode = font.getCharShape(33, 10);
+      const byName = font.getShapeByName('!', 10);
+      expect(byName).toBeDefined();
+      expect(byName!.polylines.length).toBe(byCode!.polylines.length);
+    } finally {
+      font.release();
+    }
+  }, 60_000);
+});

--- a/src/contentParser.ts
+++ b/src/contentParser.ts
@@ -8,7 +8,26 @@ const DEFAULT_FONT_SIZE = 10;
  * 
  * ['\r', '\n', '\x00']
  */
-const TERMINATING_CHARS = [0x0D, 0x0A, 0x00]
+const TERMINATING_CHARS = [0x0D, 0x0A, 0x00];
+
+/**
+ * Splits a compiled shape entry into its optional name label and bytecode payload.
+ * Shape files store an uppercase name followed by a null byte before the bytecode.
+ * Text-font entries use a leading null byte when no name is stored.
+ */
+export function splitShapeNameAndBytecode(bytes: Uint8Array): {
+  name: string | null;
+  bytecode: Uint8Array;
+} {
+  const nulIndex = bytes.indexOf(0x00);
+  if (nulIndex < 0) {
+    return { name: null, bytecode: bytes };
+  }
+
+  const name =
+    nulIndex > 0 ? new TextDecoder('ascii').decode(bytes.subarray(0, nulIndex)) : null;
+  return { name, bytecode: bytes.subarray(nulIndex + 1) };
+}
 
 /**
  * Interface for parsing the content section of a SHX font file.
@@ -44,21 +63,38 @@ class ShxShapeContentParser implements ShxContentParser {
         }
       }
 
-      const data: Record<number, Uint8Array> = {};
+      const rawData: Record<number, Uint8Array> = {};
       for (const item of items) {
         try {
           const bytes = reader.readBytes(item.length);
           if (bytes.length === item.length) {
-            data[item.code] = bytes;
+            rawData[item.code] = bytes;
           }
         } catch {
           console.warn(`Failed to read shape data for code ${item.code}`);
         }
       }
 
+      const data: Record<number, Uint8Array> = {};
+      const names: Record<string, number> = {};
+      for (const [codeKey, bytes] of Object.entries(rawData)) {
+        const code = Number(codeKey);
+        if (code === 0) {
+          data[code] = bytes;
+          continue;
+        }
+
+        const { name, bytecode } = splitShapeNameAndBytecode(bytes);
+        data[code] = bytecode;
+        if (name) {
+          names[name] = code;
+        }
+      }
+
       // Set default values first
       const fontData: ShxFontContentData = {
         data,
+        names: Object.keys(names).length > 0 ? names : undefined,
         info: '',
         baseUp: 8,
         baseDown: 2,
@@ -286,6 +322,7 @@ class ShxUnifontContentParser implements ShxContentParser {
       }
 
       const data: Record<number, Uint8Array> = {};
+      const names: Record<string, number> = {};
       for (let i = 0; i < count - 1; i++) {
         try {
           const code = reader.readUint16();
@@ -293,18 +330,14 @@ class ShxUnifontContentParser implements ShxContentParser {
           if (length > 0) {
             const bytes = reader.readBytes(length);
             if (bytes.length === length) {
-              // Parse and skip the null-terminated label at the beginning of the data
-              const nulIndex = bytes.indexOf(0x00);
-              let startOfBytecode = 0;
-
-              // Handle the null-terminated label header
-              if (nulIndex >= 0 && nulIndex < bytes.length) {
-                startOfBytecode = nulIndex + 1;
-              }
+              const { name, bytecode } = splitShapeNameAndBytecode(bytes);
 
               // Only add if we got all the bytes and there's actual bytecode data
-              if (startOfBytecode < bytes.length) {
-                data[code] = bytes.subarray(startOfBytecode);
+              if (bytecode.length > 0) {
+                data[code] = bytecode;
+                if (name) {
+                  names[name] = code;
+                }
               }
             }
           }
@@ -315,6 +348,7 @@ class ShxUnifontContentParser implements ShxContentParser {
       }
 
       fontData.data = data;
+      fontData.names = Object.keys(names).length > 0 ? names : undefined;
       return fontData;
     } catch (e) {
       console.error('Error parsing unifont:', e);

--- a/src/font.ts
+++ b/src/font.ts
@@ -48,6 +48,62 @@ export class ShxFont {
   }
 
   /**
+   * Return true if this font contains a shape with the specified name. Otherwise, return false.
+   * Shape names are matched case-insensitively.
+   * @param name - The shape name to check (for example, "GRS")
+   * @returns True if this font contains the named shape. Otherwise, return false.
+   */
+  hasShape(name: string): boolean {
+    return this.getShapeCode(name) !== undefined;
+  }
+
+  /**
+   * Gets the character code for a named shape.
+   * @param name - The shape name to look up
+   * @returns The character code, or undefined if the shape is not found
+   */
+  getShapeCode(name: string): number | undefined {
+    const names = this.fontData.content.names;
+    if (!names) {
+      return undefined;
+    }
+    return names[name.toUpperCase()];
+  }
+
+  /**
+   * Gets the shape name for a character code, if one is defined.
+   * @param code - The character code to look up
+   * @returns The shape name, or undefined if the code has no name
+   */
+  getShapeName(code: number): string | undefined {
+    const names = this.fontData.content.names;
+    if (!names) {
+      return undefined;
+    }
+    for (const [name, shapeCode] of Object.entries(names)) {
+      if (shapeCode === code) {
+        return name;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Gets the shape data for a named shape at a given font size.
+   * Shape names are matched case-insensitively.
+   * @param name - The shape name to get the shape for
+   * @param size - The desired font size
+   * @returns The shape data for the named shape, or undefined if it is not found in the font
+   */
+  getShapeByName(name: string, size: number) {
+    const code = this.getShapeCode(name);
+    if (code === undefined) {
+      return undefined;
+    }
+    return this.getCharShape(code, size);
+  }
+
+  /**
    * Gets the shape data for a specific character at a given font size.
    * @param code - The character code to get the shape for
    * @param size - The desired font size

--- a/src/fontData.ts
+++ b/src/fontData.ts
@@ -20,6 +20,8 @@ export enum ShxFontType {
 export interface ShxFontContentData {
   /** Mapping of character codes to their bitmap data */
   data: Record<number, Uint8Array>;
+  /** Mapping of shape names to character codes (shape fonts only) */
+  names?: Record<string, number>;
   /** Additional information about the font */
   info: string;
   /** Text orientation (horizontal or vertical) */


### PR DESCRIPTION
## Summary

- Parse optional null-terminated shape name prefixes from shape and unifont font entries into a `names` map on `ShxFontContentData`
- Add `ShxFont` lookup APIs: `hasShape`, `getShapeCode`, `getShapeName`, and `getShapeByName` (case-insensitive name matching)
- Update examples to display named shapes and support searching by shape name; add unit tests for name parsing and lookup

## Test plan

- [ ] Run `npm test` — verify `shapeNames.test.ts` passes
- [ ] Load a shape font (e.g. `g13f12d.shx`) in the example viewer and confirm named shapes appear in the UI
- [ ] Search by shape name (e.g. `GRS`) in the example viewer and confirm matching glyphs are shown
- [ ] Verify `font.getShapeByName('grs', size)` returns the same geometry as `font.getCharShape(code, size)`
