### PR TITLE
fix: correct repository URL for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mlightcad/cad-data"
+    "url": "https://github.com/mlightcad/shx-parser"
   },
   "homepage": "https://github.com/mlightcad/shx-parser",
   "bugs": {


### PR DESCRIPTION
## Summary

- Fix package.json repository.url from mlightcad/cad-data to mlightcad/shx-parser
- npm Trusted Publishing requires repository URL to match the GitHub repo that built the package
- 
## Test plan

- [ ] Merge and re-run release