### PR TITLE
fix: distinguish plain shape files from SHAPES text fonts

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -264,6 +264,8 @@
                 <div id="fontType" class="font-info-value"></div>
                 <div class="font-info-label">File Version:</div>
                 <div id="fileVersion" class="font-info-value"></div>
+                <div class="font-info-label">Is Font:</div>
+                <div id="isFont" class="font-info-value"></div>
                 <div class="font-info-label">Number of Characters:</div>
                 <div id="charCount" class="font-info-value"></div>
                 <div class="font-info-label" id="namedShapeLabel" style="display: none;">Named Shapes:</div>
@@ -458,6 +460,8 @@
                 // Update font information
                 document.getElementById('fontType').textContent = header.fontType;
                 document.getElementById('fileVersion').textContent = header.fileVersion;
+                const isTextFont = header.fontType !== 'shapes' || 0 in content.data;
+                document.getElementById('isFont').textContent = isTextFont ? 'Yes (text file)' : 'No (shape file)';
                 document.getElementById('charCount').textContent = Object.keys(content.data).length;
 
                 const namedShapeLabel = document.getElementById('namedShapeLabel');

--- a/src/__tests__/isFont.test.ts
+++ b/src/__tests__/isFont.test.ts
@@ -1,0 +1,43 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { ShxFont } from '../font';
+import { ShxFontType } from '../fontData';
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
+
+async function loadRemoteFont(filename: string): Promise<ShxFont> {
+  try {
+    const response = await fetch(FONT_BASE + filename);
+    if (!response.ok) {
+      throw new Error(`fetch failed: ${response.status}`);
+    }
+    return new ShxFont(await response.arrayBuffer());
+  } catch {
+    const localPath = join(process.cwd(), 'examples', 'fonts', filename);
+    const data = await readFile(localPath);
+    return new ShxFont(data.buffer);
+  }
+}
+
+describe('text font vs plain shape library (shape #0)', () => {
+  it('times.shx is a text font (shape #0 present)', async () => {
+    const font = await loadRemoteFont('times.shx');
+    try {
+      expect(font.fontData.header.fontType).toBe(ShxFontType.SHAPES);
+      expect(font.fontData.content.data[0]).toBeDefined();
+    } finally {
+      font.release();
+    }
+  }, 60_000);
+
+  it('ltypeshp.shx is a plain shape library (no shape #0)', async () => {
+    const font = await loadRemoteFont('ltypeshp.shx');
+    try {
+      expect(font.fontData.header.fontType).toBe(ShxFontType.SHAPES);
+      expect(font.fontData.content.data[0]).toBeUndefined();
+    } finally {
+      font.release();
+    }
+  }, 60_000);
+});

--- a/src/shapeParser.ts
+++ b/src/shapeParser.ts
@@ -51,11 +51,15 @@ export class ShxShapeParser {
    * @returns The parsed shape or undefined if the character is not found
    */
   getCharShape(code: number, size: number): ShxShape | undefined {
-    const fontType = this.fontData.header.fontType;
     /**
-     * For SHAPES type, size is a scale factor applied to design units (native bbox × size).
+     * Specifically, for files of type SHAPES, if shape number 0 is missing, the file is considered a shape file.
+     * For shape files, we ignore font size and treat size as a scale factor on design units (native bbox × size).
+     *
+     * @see https://help.autodesk.com/view/OARXMAC/2026/ENU/?guid=GUID-DE941DB5-7044-433C-AA68-2A9AE98A5713
+     * @see https://help.autodesk.com/view/OARXMAC/2026/ENU/?guid=GUID-9BBE5B28-DF02-4EC5-863A-BA04AB6F5EF1
      */
-    const scale = fontType === ShxFontType.SHAPES ? size : size / this.fontData.content.height;
+    const isPlainShape = this.fontData.header.fontType === ShxFontType.SHAPES && !(0 in this.fontData.content.data);
+    const scale = isPlainShape ? size : size / this.fontData.content.height;
     return this.parseAndScale(code, { factor: scale });
   }
 


### PR DESCRIPTION
For SHAPES, the .shx file actually has two subtypes: font file and shape file. Only the shape file requires resizing, so I added a condition to ensure that scaling is applied exclusively to shape files.


reference:
1. https://help.autodesk.com/view/OARXMAC/2026/ENU/?guid=GUID-DE941DB5-7044-433C-AA68-2A9AE98A5713
    > The syntax of the shape description for each shape or character is the same regardless of the final use (shape or font) for that shape description. If a shape definition file is to be used as a font file, the first entry in the file describes the font itself rather than a shape within the file. If this initial entry describes a shape, the file is used as a shape file.

2. https://help.autodesk.com/view/OARXMAC/2026/ENU/?guid=GUID-9BBE5B28-DF02-4EC5-863A-BA04AB6F5EF1
    > Text fonts must include a special shape number 0 that conveys information about the font itself. Codes 1 through 31 are for control characters, only one of which is used in a text font: