### PR TITLE
fix: align unifont glyphs with bigfont bottom edge in mixed-font text

### DIFF
--- a/src/__tests__/mixedFontAlignment.test.ts
+++ b/src/__tests__/mixedFontAlignment.test.ts
@@ -1,0 +1,66 @@
+import { ShxFont } from '../font';
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
+
+async function loadFont(name: string): Promise<ShxFont | null> {
+  try {
+    const response = await fetch(FONT_BASE + name);
+    if (!response.ok) return null;
+    return new ShxFont(await response.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+describe('mixed bigfont + unifont vertical alignment', () => {
+  it('aligns tssdeng digits with hztxt hanzi on a shared bottom edge at minY=0', async () => {
+    const tssdeng = await loadFont('tssdeng.shx');
+    const hztxt = await loadFont('hztxt.shx');
+    if (!tssdeng || !hztxt) return;
+
+    try {
+      const size = 16;
+      const digit = tssdeng.getCharShape(56, size)!;
+      const han = hztxt.getCharShape(0xb1df, size)!;
+
+      expect(digit.bbox.minY).toBeCloseTo(0, 5);
+      expect(han.bbox.minY).toBeCloseTo(0, 5);
+      expect(digit.bbox.maxY).toBeGreaterThan(0);
+      expect(han.bbox.maxY).toBeGreaterThan(0);
+    } finally {
+      tssdeng.release();
+      hztxt.release();
+    }
+  }, 60_000);
+
+  it('does not invert isocp uppercase letters that already extend above y=0', async () => {
+    const isocp = await loadFont('isocp.shx');
+    if (!isocp) return;
+
+    try {
+      const size = 16;
+      const letterA = isocp.getCharShape(65, size)!;
+      expect(letterA.bbox.maxY).toBeGreaterThan(0);
+    } finally {
+      isocp.release();
+    }
+  }, 60_000);
+
+  it('bigfont normalizeToOrigin still shifts body glyphs up to minY=0', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const parser = (hztxt as unknown as {
+        shapeParser: { getCharShape(c: number, s: number): import('../shape').ShxShape };
+      }).shapeParser;
+      const raw = parser.getCharShape(0xb1df, 16);
+      const final = hztxt.getCharShape(0xb1df, 16)!;
+
+      expect(final.bbox.minY).toBe(0);
+      expect(raw.bbox.minY).toBeGreaterThan(0);
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+});

--- a/src/font.ts
+++ b/src/font.ts
@@ -117,14 +117,28 @@ export class ShxFont {
    */
   public getCharShape(code: number, size: number) {
     let shape = this.shapeParser.getCharShape(code, size);
-    if (shape && this.fontData.header.fontType === ShxFontType.BIGFONT) {
+    if (!shape) {
+      return undefined;
+    }
+
+    const fontType = this.fontData.header.fontType;
+
+    if (fontType === ShxFontType.BIGFONT) {
       // Normalize baseline-aligned and mid-cell body glyphs to the origin.
       // Top/center punctuation (e.g. “一”, quotation marks) sit in the upper
       // half of the cell and must keep their vertical position.
       if (shape.bbox.minY <= size * 0.5) {
         shape = shape.normalizeToOrigin();
       }
+    } else if (fontType === ShxFontType.UNIFONT) {
+      // Some unifont files (e.g. tssdeng.shx) encode body strokes in negative Y
+      // with maxY on the baseline. Shift to cell-bottom origin so mixed
+      // bigfont + unifont lines share minY = 0 as the bottom edge.
+      if (shape.bbox.minY < 0 && shape.bbox.maxY <= 0) {
+        shape = shape.normalizeToOrigin();
+      }
     }
+
     return shape;
   }
 


### PR DESCRIPTION
## Summary

- Normalize UNIFONT glyphs that encode body strokes entirely below the baseline (e.g. tssdeng.shx digits) so mixed bigfont + unifont lines share minY = 0 as the bottom edge
- Preserve glyphs that extend above y = 0 (e.g. isocp uppercase letters) by only shifting when minY < 0 and maxY <= 0
- Add integration tests covering tssdeng/hztxt alignment, isocp regression, and bigfont normalization behavior

## Test plan

- [x] pm test — all 141 tests pass, including new mixedFontAlignment suite
- [x] pm run lint — no ESLint issues