### PR TITLE
fix: tolerate unifont baseline float noise and avoid mutating cached shapes

### DIFF
--- a/src/__tests__/mixedFontAlignment.test.ts
+++ b/src/__tests__/mixedFontAlignment.test.ts
@@ -33,6 +33,22 @@ describe('mixed bigfont + unifont vertical alignment', () => {
     }
   }, 60_000);
 
+  it('aligns aehalf baseline glyphs consistently despite float noise at maxY=0', async () => {
+    const aehalf = await loadFont('aehalf.shx');
+    if (!aehalf) return;
+
+    try {
+      const size = 16;
+      const codes = [83, 72, 116, 50, 53]; // S, H, t, 2, 5
+      for (const code of codes) {
+        const shape = aehalf.getCharShape(code, size)!;
+        expect(shape.bbox.minY).toBeCloseTo(0, 5);
+      }
+    } finally {
+      aehalf.release();
+    }
+  }, 60_000);
+
   it('does not invert isocp uppercase letters that already extend above y=0', async () => {
     const isocp = await loadFont('isocp.shx');
     if (!isocp) return;

--- a/src/font.ts
+++ b/src/font.ts
@@ -4,6 +4,9 @@ import { ShxHeaderParser } from './headerParser';
 import { ShxContentParserFactory } from './contentParser';
 import { ShxShapeParser } from './shapeParser';
 
+/** Treat arc/line tessellation noise at the baseline as y=0 for unifont alignment. */
+const UNIFONT_BASELINE_EPSILON = 1e-6;
+
 /**
  * Represents a SHX font and provides methods to parse and render its characters.
  * This class handles the loading and parsing of SHX font files, and provides
@@ -128,14 +131,14 @@ export class ShxFont {
       // Top/center punctuation (e.g. “一”, quotation marks) sit in the upper
       // half of the cell and must keep their vertical position.
       if (shape.bbox.minY <= size * 0.5) {
-        shape = shape.normalizeToOrigin();
+        shape = shape.normalizeToOrigin(true);
       }
     } else if (fontType === ShxFontType.UNIFONT) {
       // Some unifont files (e.g. tssdeng.shx) encode body strokes in negative Y
       // with maxY on the baseline. Shift to cell-bottom origin so mixed
       // bigfont + unifont lines share minY = 0 as the bottom edge.
-      if (shape.bbox.minY < 0 && shape.bbox.maxY <= 0) {
-        shape = shape.normalizeToOrigin();
+      if (shape.bbox.minY < 0 && shape.bbox.maxY <= UNIFONT_BASELINE_EPSILON) {
+        shape = shape.normalizeToOrigin(true);
       }
     }
 


### PR DESCRIPTION
## Summary
- Treat unifont glyphs whose `maxY` is within `1e-6` of the baseline as baseline-aligned, fixing missed normalization for fonts like `aehalf.shx` where arc tessellation leaves tiny positive `maxY` values.
- Call `normalizeToOrigin(true)` for bigfont and unifont alignment so cached shapes in the shape parser are not mutated in place.
- Add a regression test covering `aehalf.shx` baseline alignment for mixed-font text.

## Test plan
- [x] `npm test -- --testPathPattern=mixedFontAlignment`
- [x] `npm test` (144 tests pass)