### PR TITLE
fix: separate text layout from raw geometry and fix bigfont advance

### DIFF
--- a/src/__tests__/font.test.ts
+++ b/src/__tests__/font.test.ts
@@ -1,5 +1,7 @@
-import { ShxFont } from '../font';
+import { ShxFont, alignShxGlyphForLayout } from '../font';
 import { ShxFontData, ShxFontType } from '../fontData';
+import { Point } from '../point';
+import { ShxShape } from '../shape';
 
 function createBigFontData(shapes: Record<number, Uint8Array>): ShxFontData {
   return {
@@ -22,16 +24,21 @@ function createBigFontData(shapes: Record<number, Uint8Array>): ShxFontData {
 }
 
 describe('ShxFont', () => {
-  describe('getCharShape bigfont alignment', () => {
+  describe('getCharShape returns scaled raw geometry', () => {
     // Horizontal line along the baseline: pen down, draw 8 units east, pen up, end.
     const baselineShape = new Uint8Array([0x01, 0x80, 0x02, 0x00]);
     // Horizontal line near the top of the cell: move to (0, 7), pen down, draw east, pen up, end.
     const topAlignedShape = new Uint8Array([0x02, 0x08, 0x00, 0x07, 0x01, 0x80, 0x02, 0x00]);
+    // Small mark in the upper cell (like hztxt quotation at GBK 0xA1B0): short stroke at y=3.
+    const topPunctuationShape = new Uint8Array([
+      0x02, 0x08, 0x00, 0x03, 0x01, 0x40, 0x02, 0x00,
+    ]);
 
     const font = new ShxFont(
       createBigFontData({
         1: baselineShape,
         2: topAlignedShape,
+        3: topPunctuationShape,
       })
     );
 
@@ -39,7 +46,7 @@ describe('ShxFont', () => {
       font.release();
     });
 
-    it('normalizes baseline-aligned bigfont glyphs to the origin', () => {
+    it('returns baseline-aligned bigfont glyphs at y=0 unchanged', () => {
       const size = 16;
       const shape = font.getCharShape(1, size);
 
@@ -54,6 +61,163 @@ describe('ShxFont', () => {
 
       expect(shape).toBeDefined();
       expect(shape!.bbox.minY).toBeCloseTo(14);
+    });
+
+    it('preserves encoded vertical position for top punctuation (no cap alignment)', () => {
+      const size = 16;
+      const shape = font.getCharShape(3, size);
+
+      expect(shape).toBeDefined();
+      // y=3 in an 8-unit cell, scaled to size 16 → minY ≈ 6
+      expect(shape!.bbox.minY).toBeCloseTo(6);
+      expect(shape!.bbox.maxY).toBeCloseTo(6);
+    });
+
+    it('matches shapeParser output without post-processing', () => {
+      const size = 16;
+      const parser = (font as unknown as {
+        shapeParser: { getCharShape(c: number, s: number): import('../shape').ShxShape };
+      }).shapeParser;
+
+      for (const code of [1, 2, 3]) {
+        const raw = parser.getCharShape(code, size);
+        const fromFont = font.getCharShape(code, size);
+        if (!raw || !fromFont) {
+          throw new Error(`Expected shapes for code ${code}`);
+        }
+        expect(fromFont.bbox).toEqual(raw.bbox);
+        expect(fromFont.lastPoint?.x).toBeCloseTo(raw.lastPoint?.x ?? 0);
+      }
+    });
+  });
+
+  describe('getFontMetrics', () => {
+    const font = new ShxFont(
+      createBigFontData({
+        1: new Uint8Array([0x01, 0x80, 0x02, 0x00]),
+      })
+    );
+
+    afterAll(() => {
+      font.release();
+    });
+
+    it('scales baseUp and baseDown from shape #0', () => {
+      const metrics = font.getFontMetrics(16);
+      expect(metrics.size).toBe(16);
+      expect(metrics.capHeight).toBeCloseTo(14);
+      expect(metrics.descenderHeight).toBeCloseTo(2);
+      expect(metrics.totalHeight).toBeCloseTo(16);
+      expect(metrics.cellWidth).toBeCloseTo(16);
+    });
+  });
+
+  describe('alignShxGlyphForLayout', () => {
+    const bigfontData = createBigFontData({ 1: new Uint8Array([0x01, 0x80, 0x02, 0x00]) });
+
+    it('normalizes mid-cell bigfont body glyphs to the origin', () => {
+      const size = 16;
+      const shape = new ShxShape(new Point(8, 0), [
+        [new Point(0, 4), new Point(8, 12)],
+      ]);
+      const aligned = alignShxGlyphForLayout(shape, bigfontData, size);
+      expect(aligned.bbox.minY).toBeCloseTo(0);
+    });
+
+    it('aligns bigfont top punctuation to the cap band', () => {
+      const size = 16;
+      const shape = new ShxShape(new Point(8, 0), [
+        [new Point(2, 6), new Point(4, 8)],
+      ]);
+      const aligned = alignShxGlyphForLayout(shape, bigfontData, size);
+      expect(aligned.bbox.maxY).toBeCloseTo(14);
+    });
+
+    it('lifts bigfont baseline punctuation to y=0', () => {
+      const size = 16;
+      const shape = new ShxShape(new Point(8, 0), [
+        [new Point(2, 2), new Point(4, 4)],
+      ]);
+      const aligned = alignShxGlyphForLayout(shape, bigfontData, size);
+      expect(aligned.bbox.minY).toBeCloseTo(0);
+    });
+
+    it('normalizes unifont glyphs with negative Y to the baseline', () => {
+      const unifontData: ShxFontData = {
+        header: { fontType: ShxFontType.UNIFONT, fileHeader: 'test', fileVersion: '1.0' },
+        content: {
+          data: {},
+          info: '',
+          orientation: 'horizontal',
+          baseUp: 8,
+          baseDown: 2,
+          height: 10,
+          width: 10,
+          isExtended: false,
+        },
+      };
+      const size = 16;
+      const shape = new ShxShape(new Point(6, 0), [
+        [new Point(0, -4), new Point(6, 0)],
+      ]);
+      const aligned = alignShxGlyphForLayout(shape, unifontData, size);
+      expect(aligned.bbox.minY).toBeCloseTo(0);
+    });
+
+    it('extends narrow unifont advance to ink extent', () => {
+      const unifontData: ShxFontData = {
+        header: { fontType: ShxFontType.UNIFONT, fileHeader: 'test', fileVersion: '1.0' },
+        content: {
+          data: {},
+          info: '',
+          orientation: 'horizontal',
+          baseUp: 8,
+          baseDown: 2,
+          height: 10,
+          width: 10,
+          isExtended: false,
+        },
+      };
+      const size = 16;
+      const shape = new ShxShape(new Point(1, 0), [
+        [new Point(0, 2), new Point(1.5, 4)],
+      ]);
+      const aligned = alignShxGlyphForLayout(shape, unifontData, size);
+      expect(aligned.lastPoint?.x).toBeCloseTo(1.5);
+    });
+
+    it('centers zero-height unifont strokes in the cap band', () => {
+      const unifontData: ShxFontData = {
+        header: { fontType: ShxFontType.UNIFONT, fileHeader: 'test', fileVersion: '1.0' },
+        content: {
+          data: {},
+          info: '',
+          orientation: 'horizontal',
+          baseUp: 8,
+          baseDown: 2,
+          height: 10,
+          width: 10,
+          isExtended: false,
+        },
+      };
+      const size = 16;
+      const shape = new ShxShape(new Point(4, 0), [
+        [new Point(2, 0), new Point(2, 0)],
+      ]);
+      const aligned = alignShxGlyphForLayout(shape, unifontData, size);
+      expect(aligned.bbox.minY).toBeGreaterThan(0);
+      expect(aligned.bbox.maxY).toBeLessThan(size);
+    });
+  });
+
+  describe('getLayoutCharShape', () => {
+    it('returns undefined for missing glyphs', () => {
+      const font = new ShxFont(createBigFontData({}));
+      try {
+        expect(font.getLayoutCharShape(999, 16)).toBeUndefined();
+      } finally {
+        font.release();
+      }
     });
   });
 });

--- a/src/__tests__/gdtGlyphs.test.ts
+++ b/src/__tests__/gdtGlyphs.test.ts
@@ -48,8 +48,8 @@ describe('GDT font glyphs (gdt.shx)', () => {
       const inner = polylineCenter(shape, 1);
       expect(inner.x).toBeCloseTo(outer.x, 1);
       expect(inner.y).toBeCloseTo(outer.y, 1);
-      expect(shape.bbox.maxX).toBeLessThan(size);
-      expect(shape.bbox.maxY).toBeLessThan(size * 0.25);
+      expect(shape.bbox.maxX - shape.bbox.minX).toBeLessThan(size * 1.15);
+      expect(shape.bbox.maxY - shape.bbox.minY).toBeLessThan(size * 1.15);
     } finally {
       font.release();
     }

--- a/src/__tests__/glyphLayout.test.ts
+++ b/src/__tests__/glyphLayout.test.ts
@@ -1,0 +1,50 @@
+import { ShxFont, alignShxGlyphForLayout, computeFontMetrics } from '../font';
+import { resolveAdvanceWidth, layoutTextRun } from '../textLayout';
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
+
+async function loadFont(name: string): Promise<ShxFont | null> {
+  try {
+    const response = await fetch(FONT_BASE + name);
+    if (!response.ok) return null;
+    return new ShxFont(await response.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+describe('glyph layout alignment', () => {
+  it('preserves full cell advance for hztxt baseline comma after alignment', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      const raw = hztxt.getCharShape(0xa3ac, size)!;
+      const aligned = alignShxGlyphForLayout(raw, hztxt.fontData, size);
+      const metrics = computeFontMetrics(hztxt.fontData.content, size);
+
+      expect(resolveAdvanceWidth(aligned, hztxt.fontData, size)).toBeCloseTo(metrics.cellWidth, 0);
+      expect(aligned.lastPoint!.x).toBeCloseTo(raw.lastPoint!.x, 1);
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+
+  it('leaves enough ink gap between hztxt comma and G', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      const placed = layoutTextRun([
+        { font: hztxt, code: 0xa3ac, size },
+        { font: hztxt, code: 0xa3c7, size },
+      ]);
+      const gap = placed[1].shape.bbox.minX - placed[0].shape.bbox.maxX;
+      expect(gap).toBeGreaterThan(size * 0.3);
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+});

--- a/src/__tests__/hztxtComma.test.ts
+++ b/src/__tests__/hztxtComma.test.ts
@@ -1,0 +1,97 @@
+import { ShxFont } from '../font';
+import { getAdvanceWidth, layoutTextRun } from '../textLayout';
+
+const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
+
+async function loadFont(name: string): Promise<ShxFont | null> {
+  try {
+    const response = await fetch(FONT_BASE + name);
+    if (!response.ok) return null;
+    return new ShxFont(await response.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+describe('punctuation spacing (raw geometry + layout)', () => {
+  it('returns hztxt halfwidth comma without baseline Y normalization', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      const parser = (hztxt as unknown as {
+        shapeParser: { getCharShape(c: number, s: number): import('../shape').ShxShape };
+      }).shapeParser;
+      const raw = parser.getCharShape(0xa3a4, size);
+      const fromFont = hztxt.getCharShape(0xa3a4, size)!;
+
+      expect(fromFont.bbox.minY).toBeCloseTo(raw.bbox.minY, 5);
+      expect(fromFont.bbox.minX).toBeCloseTo(raw.bbox.minX, 5);
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+
+  it('reports tssdeng comma advance from the SHX pen-up vector', async () => {
+    const tssdeng = await loadFont('tssdeng.shx');
+    if (!tssdeng) return;
+
+    try {
+      const size = 16;
+      const comma = tssdeng.getCharShape(0x2c, size)!;
+
+      expect(comma.lastPoint).toBeDefined();
+      expect(getAdvanceWidth(comma)).toBe(comma.lastPoint!.x);
+      expect(comma.bbox.maxX).toBeGreaterThan(comma.lastPoint!.x);
+    } finally {
+      tssdeng.release();
+    }
+  }, 60_000);
+
+  it('applies hztxt terminal advance primitive #2 as full cell width', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      const comma = hztxt.getCharShape(0xa3ac, size)!;
+      const letterG = hztxt.getCharShape(0xa3c7, size)!;
+      const ideoComma = hztxt.getCharShape(0xa1a2, size)!;
+      const period = hztxt.getCharShape(0xa1a3, size)!;
+
+      for (const shape of [comma, letterG, ideoComma, period]) {
+        expect(getAdvanceWidth(shape)).toBeCloseTo(size, 0);
+      }
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+
+  it('lays out hztxt punctuation without overlapping or extreme gaps', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      // GBK codes for ",G" and "、0" and "1。" substrings from mixed mtext runs
+      const placed = layoutTextRun([
+        { font: hztxt, code: 0xa3ac, size },
+        { font: hztxt, code: 0xa3c7, size },
+        { font: hztxt, code: 0xa1a2, size },
+        { font: hztxt, code: 0xa3b0, size },
+        { font: hztxt, code: 0xa3b1, size },
+        { font: hztxt, code: 0xa1a3, size },
+      ]);
+
+      expect(placed).toHaveLength(6);
+      for (let i = 1; i < placed.length; i++) {
+        const gap = placed[i].shape.bbox.minX - placed[i - 1].shape.bbox.maxX;
+        expect(gap).toBeGreaterThan(size * 0.3);
+        expect(gap).toBeLessThan(size * 0.9);
+      }
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+});

--- a/src/__tests__/mixedFontAlignment.test.ts
+++ b/src/__tests__/mixedFontAlignment.test.ts
@@ -1,4 +1,5 @@
 import { ShxFont } from '../font';
+import { layoutTextRun, resolveAdvanceWidth } from '../textLayout';
 
 const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
 
@@ -12,44 +13,104 @@ async function loadFont(name: string): Promise<ShxFont | null> {
   }
 }
 
-describe('mixed bigfont + unifont vertical alignment', () => {
-  it('aligns tssdeng digits with hztxt hanzi on a shared bottom edge at minY=0', async () => {
+function getShapeParser(font: ShxFont) {
+  return (font as unknown as {
+    shapeParser: { getCharShape(c: number, s: number): import('../shape').ShxShape };
+  }).shapeParser;
+}
+
+describe('font metrics and text layout', () => {
+  it('getCharShape returns the same geometry as shapeParser (no alignment pass)', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      const parser = getShapeParser(hztxt);
+      for (const code of [0xb1df, 0xa1b0, 0xa1a2, 0xa3a4]) {
+        const raw = parser.getCharShape(code, size);
+        const fromFont = hztxt.getCharShape(code, size)!;
+        expect(fromFont.bbox.minX).toBeCloseTo(raw.bbox.minX, 5);
+        expect(fromFont.bbox.minY).toBeCloseTo(raw.bbox.minY, 5);
+        expect(fromFont.bbox.maxX).toBeCloseTo(raw.bbox.maxX, 5);
+        expect(fromFont.bbox.maxY).toBeCloseTo(raw.bbox.maxY, 5);
+      }
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+
+  it('exposes scaled font metrics from shape #0 for mixed-font rendering', async () => {
     const tssdeng = await loadFont('tssdeng.shx');
     const hztxt = await loadFont('hztxt.shx');
     if (!tssdeng || !hztxt) return;
 
     try {
       const size = 16;
-      const digit = tssdeng.getCharShape(56, size)!;
-      const han = hztxt.getCharShape(0xb1df, size)!;
+      const tMetrics = tssdeng.getFontMetrics(size);
+      const hMetrics = hztxt.getFontMetrics(size);
 
-      expect(digit.bbox.minY).toBeCloseTo(0, 5);
-      expect(han.bbox.minY).toBeCloseTo(0, 5);
-      expect(digit.bbox.maxY).toBeGreaterThan(0);
-      expect(han.bbox.maxY).toBeGreaterThan(0);
+      expect(tMetrics.capHeight).toBeGreaterThan(0);
+      expect(hMetrics.capHeight).toBeCloseTo(size, 1);
+      expect(hMetrics.descenderHeight).toBe(0);
+      expect(hztxt.getFontMetrics(size).capHeight).toBe(hMetrics.capHeight);
     } finally {
       tssdeng.release();
       hztxt.release();
     }
   }, 60_000);
 
-  it('aligns aehalf baseline glyphs consistently despite float noise at maxY=0', async () => {
-    const aehalf = await loadFont('aehalf.shx');
-    if (!aehalf) return;
+  it('layoutTextRun aligns mixed-font glyphs on a shared baseline', async () => {
+    const tssdeng = await loadFont('tssdeng.shx');
+    const hztxt = await loadFont('hztxt.shx');
+    if (!tssdeng || !hztxt) return;
 
     try {
       const size = 16;
-      const codes = [83, 72, 116, 50, 53]; // S, H, t, 2, 5
-      for (const code of codes) {
-        const shape = aehalf.getCharShape(code, size)!;
-        expect(shape.bbox.minY).toBeCloseTo(0, 5);
-      }
+      const digitLayout = tssdeng.getLayoutCharShape(56, size)!;
+      const hanLayout = hztxt.getLayoutCharShape(0xb1df, size)!;
+
+      const placed = layoutTextRun([
+        { font: tssdeng, code: 56, size },
+        { font: hztxt, code: 0xb1df, size },
+      ]);
+
+      expect(placed).toHaveLength(2);
+      expect(placed[0].shape.bbox.minY).toBeCloseTo(digitLayout.bbox.minY, 5);
+      expect(placed[1].shape.bbox.minY).toBeCloseTo(hanLayout.bbox.minY, 5);
+      expect(placed[1].x).toBeCloseTo(
+        resolveAdvanceWidth(digitLayout, tssdeng.fontData, size),
+        5
+      );
     } finally {
-      aehalf.release();
+      tssdeng.release();
+      hztxt.release();
     }
   }, 60_000);
 
-  it('does not invert isocp uppercase letters that already extend above y=0', async () => {
+  it('preserves encoded vertical positions for hztxt punctuation types', async () => {
+    const hztxt = await loadFont('hztxt.shx');
+    if (!hztxt) return;
+
+    try {
+      const size = 16;
+      // GBK: U+201C/U+201D — top quotation marks sit above mid-cell
+      for (const code of [0xa1b0, 0xa1b1]) {
+        const shape = hztxt.getCharShape(code, size)!;
+        expect(shape.bbox.maxY).toBeLessThan(size);
+        expect(shape.bbox.minY).toBeGreaterThan(0);
+      }
+      // GBK: U+3001/U+3002 — baseline punctuation
+      for (const code of [0xa1a2, 0xa1a3]) {
+        const shape = hztxt.getCharShape(code, size)!;
+        expect(shape.bbox.maxY).toBeLessThan(size * 0.5);
+      }
+    } finally {
+      hztxt.release();
+    }
+  }, 60_000);
+
+  it('does not invert isocp uppercase letters that extend above y=0', async () => {
     const isocp = await loadFont('isocp.shx');
     if (!isocp) return;
 
@@ -62,21 +123,19 @@ describe('mixed bigfont + unifont vertical alignment', () => {
     }
   }, 60_000);
 
-  it('bigfont normalizeToOrigin still shifts body glyphs up to minY=0', async () => {
-    const hztxt = await loadFont('hztxt.shx');
-    if (!hztxt) return;
+  it('preserves relative vertical positions within unifont families', async () => {
+    const aehalf = await loadFont('aehalf.shx');
+    if (!aehalf) return;
 
     try {
-      const parser = (hztxt as unknown as {
-        shapeParser: { getCharShape(c: number, s: number): import('../shape').ShxShape };
-      }).shapeParser;
-      const raw = parser.getCharShape(0xb1df, 16);
-      const final = hztxt.getCharShape(0xb1df, 16)!;
+      const size = 16;
+      const tilde = aehalf.getCharShape(126, size)!;
+      const digit = aehalf.getCharShape(50, size)!;
 
-      expect(final.bbox.minY).toBe(0);
-      expect(raw.bbox.minY).toBeGreaterThan(0);
+      expect(tilde.bbox.minY).toBeGreaterThan(digit.bbox.minY);
+      expect(tilde.bbox.maxY).toBeLessThan(digit.bbox.maxY);
     } finally {
-      hztxt.release();
+      aehalf.release();
     }
   }, 60_000);
 });

--- a/src/__tests__/textLayout.test.ts
+++ b/src/__tests__/textLayout.test.ts
@@ -1,0 +1,131 @@
+import { computeFontMetrics, ShxFont } from '../font';
+import { ShxFontData, ShxFontType } from '../fontData';
+import { Point } from '../point';
+import { ShxShape } from '../shape';
+import { getAdvanceWidth, layoutTextRun, placeGlyphOnBaseline, resolveAdvanceWidth } from '../textLayout';
+
+function makeFontData(fontType: ShxFontType): ShxFontData {
+  return {
+    header: { fontType, fileHeader: 'test', fileVersion: '1.0' },
+    content: {
+      data: {},
+      info: '',
+      orientation: 'horizontal',
+      baseUp: 8,
+      baseDown: 2,
+      height: 10,
+      width: 10,
+      isExtended: false,
+    },
+  };
+}
+
+function makeShape(lastX: number, minX = 0, maxX = lastX, lastPoint?: Point): ShxShape {
+  return new ShxShape(lastPoint ?? new Point(lastX, 0), [
+    [new Point(minX, 0), new Point(maxX, 0)],
+  ]);
+}
+
+function makeMockFont(getShape: () => ShxShape | undefined): ShxFont {
+  const fontData = {
+    header: { fontType: ShxFontType.SHAPES, fileHeader: 'test', fileVersion: '1.0' },
+    content: {
+      data: {},
+      info: '',
+      orientation: 'horizontal' as const,
+      baseUp: 8,
+      baseDown: 2,
+      height: 10,
+      width: 10,
+      isExtended: false,
+    },
+  };
+  return {
+    fontData,
+    getCharShape: jest.fn(getShape),
+    getLayoutCharShape: jest.fn(getShape),
+  } as unknown as ShxFont;
+}
+
+describe('textLayout', () => {
+  describe('resolveAdvanceWidth', () => {
+    it('returns pen advance for narrow glyphs', () => {
+      const fontData = makeFontData(ShxFontType.UNIFONT);
+      const size = 16;
+      const shape = makeShape(4, 0, 2);
+      expect(resolveAdvanceWidth(shape, fontData, size)).toBe(4);
+    });
+
+    it('uses full cell width for bigfont glyphs', () => {
+      const fontData = makeFontData(ShxFontType.BIGFONT);
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const shape = makeShape(cellWidth, 0, cellWidth * 0.8);
+      expect(resolveAdvanceWidth(shape, fontData, size)).toBeCloseTo(cellWidth);
+    });
+
+    it('extends advance when unifont ink exceeds pen vector', () => {
+      const fontData = makeFontData(ShxFontType.UNIFONT);
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const shape = makeShape(4, 0, cellWidth * 0.8);
+      expect(resolveAdvanceWidth(shape, fontData, size)).toBeCloseTo(cellWidth);
+    });
+
+    it('uses ink extent for narrow unifont glyphs', () => {
+      const fontData = makeFontData(ShxFontType.UNIFONT);
+      const size = 16;
+      const shape = makeShape(2, 0, 3);
+      expect(resolveAdvanceWidth(shape, fontData, size)).toBe(2);
+    });
+  });
+
+  describe('getAdvanceWidth', () => {
+    it('uses lastPoint.x when present', () => {
+      expect(getAdvanceWidth(makeShape(10, 0, 12))).toBe(10);
+    });
+
+    it('falls back to bbox width when lastPoint is absent', () => {
+      const shape = new ShxShape(undefined, [[new Point(0, 0), new Point(10, 0)]]);
+      expect(getAdvanceWidth(shape)).toBe(10);
+    });
+  });
+
+  describe('placeGlyphOnBaseline', () => {
+    it('translates the glyph without changing relative geometry', () => {
+      const shape = new ShxShape(new Point(8, 0), [
+        [new Point(0, 0), new Point(8, 0)],
+        [new Point(2, 3), new Point(4, 5)],
+      ]);
+      const placed = placeGlyphOnBaseline(shape, 10, 20);
+
+      expect(placed.bbox.minX).toBeCloseTo(10);
+      expect(placed.bbox.minY).toBeCloseTo(20);
+      expect(placed.bbox.maxX - placed.bbox.minX).toBeCloseTo(8);
+    });
+  });
+
+  describe('layoutTextRun', () => {
+    it('places glyphs horizontally using advance widths', () => {
+      const fontA = makeMockFont(() => makeShape(5, 0, 5));
+      const fontB = makeMockFont(() => makeShape(7, 0, 7));
+
+      const placed = layoutTextRun([
+        { font: fontA, code: 65, size: 16 },
+        { font: fontB, code: 66, size: 16 },
+      ]);
+
+      expect(placed).toHaveLength(2);
+      expect(placed[0].x).toBe(0);
+      expect(placed[1].x).toBe(5);
+      expect(placed[0].shape.bbox.minX).toBe(0);
+      expect(placed[1].shape.bbox.minX).toBe(5);
+    });
+
+    it('skips missing glyphs', () => {
+      const font = makeMockFont(() => undefined);
+
+      expect(layoutTextRun([{ font, code: 65, size: 16 }])).toEqual([]);
+    });
+  });
+});

--- a/src/font.ts
+++ b/src/font.ts
@@ -1,11 +1,242 @@
 import { ShxFileReader } from './fileReader';
-import { ShxFontData, ShxFontType } from './fontData';
+import { ShxFontContentData, ShxFontData, ShxFontType } from './fontData';
 import { ShxHeaderParser } from './headerParser';
 import { ShxContentParserFactory } from './contentParser';
+import { Point } from './point';
 import { ShxShapeParser } from './shapeParser';
+import { ShxShape } from './shape';
 
 /** Treat arc/line tessellation noise at the baseline as y=0 for unifont alignment. */
-const UNIFONT_BASELINE_EPSILON = 1e-6;
+const LAYOUT_BASELINE_EPSILON = 1e-6;
+
+/**
+ * Computes scaled font metrics for a target render size.
+ *
+ * @param content - Parsed font content from shape #0
+ * @param size - Target font size in drawing units
+ */
+export function computeFontMetrics(content: ShxFontContentData, size: number): ShxFontMetrics {
+  const { height, width, baseUp, baseDown } = content;
+  const scale = height > 0 ? size / height : 1;
+  const capHeight = scale * baseUp;
+  const descenderHeight = scale * baseDown;
+  return {
+    size,
+    capHeight,
+    descenderHeight,
+    cellWidth: scale * width,
+    totalHeight: capHeight + descenderHeight,
+  };
+}
+
+function scaledCapHeight(content: ShxFontContentData, size: number): number {
+  return computeFontMetrics(content, size).capHeight;
+}
+
+function verticalBaselineBand(content: ShxFontContentData, size: number): number {
+  const { height, baseDown } = content;
+  if (height <= 0) {
+    return LAYOUT_BASELINE_EPSILON;
+  }
+  return Math.max(size * (baseDown / height), LAYOUT_BASELINE_EPSILON);
+}
+
+function isVerticalTextShapesFont(fontType: ShxFontType, content: ShxFontContentData): boolean {
+  return (
+    fontType === ShxFontType.SHAPES &&
+    content.orientation === 'vertical' &&
+    content.data[0] !== undefined
+  );
+}
+
+function usesVerticalNegativeYAlignment(fontType: ShxFontType, content: ShxFontContentData): boolean {
+  return fontType === ShxFontType.UNIFONT || isVerticalTextShapesFont(fontType, content);
+}
+
+function hasFiniteGlyphHeight(bbox: { minY: number; maxY: number }): boolean {
+  const height = bbox.maxY - bbox.minY;
+  return Number.isFinite(height) && height > LAYOUT_BASELINE_EPSILON;
+}
+
+function shouldNormalizeBigfontBodyGlyph(bbox: { minY: number; maxY: number }, size: number): boolean {
+  if (!hasFiniteGlyphHeight(bbox)) {
+    return false;
+  }
+  const { minY, maxY } = bbox;
+  if (minY <= LAYOUT_BASELINE_EPSILON) {
+    return false;
+  }
+  const height = maxY - minY;
+  if (minY >= size * 0.5) {
+    return false;
+  }
+  if (height < size * 0.5) {
+    return false;
+  }
+  return true;
+}
+
+function isBigfontBaselinePunctuation(bbox: { minY: number; maxY: number }, size: number): boolean {
+  if (!hasFiniteGlyphHeight(bbox)) {
+    return false;
+  }
+  const height = bbox.maxY - bbox.minY;
+  return bbox.minY <= size * 0.2 && height < size * 0.5;
+}
+
+function isBigfontTopPunctuation(bbox: { minY: number; maxY: number }, size: number): boolean {
+  if (!hasFiniteGlyphHeight(bbox)) {
+    return false;
+  }
+  const height = bbox.maxY - bbox.minY;
+  return bbox.minY > size * 0.2 && height < size * 0.5;
+}
+
+function isZeroHeightBaselineStroke(
+  bbox: { minY: number; maxY: number },
+  content: ShxFontContentData,
+  size: number
+): boolean {
+  const height = bbox.maxY - bbox.minY;
+  if (height > LAYOUT_BASELINE_EPSILON) {
+    return false;
+  }
+  const band = verticalBaselineBand(content, size);
+  return (
+    Math.abs(bbox.minY) <= band + LAYOUT_BASELINE_EPSILON &&
+    Math.abs(bbox.maxY) <= band + LAYOUT_BASELINE_EPSILON
+  );
+}
+
+function isSmallCapPunctuation(bbox: { minY: number; maxY: number }, size: number): boolean {
+  const height = bbox.maxY - bbox.minY;
+  if (height <= LAYOUT_BASELINE_EPSILON) {
+    return false;
+  }
+  if (height >= size * 0.5) {
+    return false;
+  }
+  if (bbox.minY > size * 0.2) {
+    return false;
+  }
+  return height <= size * 0.3;
+}
+
+function centerInCapBand(shape: ShxShape, content: ShxFontContentData, size: number): ShxShape {
+  const capHeight = scaledCapHeight(content, size);
+  const targetCenterY = capHeight * 0.5;
+  const bbox = shape.bbox;
+  const currentCenterY = (bbox.minY + bbox.maxY) / 2;
+  return shape.offset(new Point(0, targetCenterY - currentCenterY), true);
+}
+
+function extendNarrowGlyphAdvance(shape: ShxShape, size: number): ShxShape {
+  const { maxX } = shape.bbox;
+  const lastPoint = shape.lastPoint;
+  if (maxX >= size * 0.12 || !lastPoint || lastPoint.x >= maxX - LAYOUT_BASELINE_EPSILON) {
+    return shape;
+  }
+  return new ShxShape(new Point(maxX, lastPoint.y), shape.polylines);
+}
+
+function alignBigfontGlyph(shape: ShxShape, content: ShxFontContentData, size: number): ShxShape {
+  const bbox = shape.bbox;
+
+  if (Number.isFinite(bbox.minY) && bbox.minY < -LAYOUT_BASELINE_EPSILON) {
+    shape = shape.offset(new Point(0, -bbox.minY), true);
+  } else if (isBigfontBaselinePunctuation(shape.bbox, size)) {
+    // Baseline punctuation keeps its encoded horizontal slot; only lift to y=0.
+    if (Math.abs(shape.bbox.minY) > LAYOUT_BASELINE_EPSILON) {
+      shape = shape.offset(new Point(0, -shape.bbox.minY), true);
+    }
+  } else if (shouldNormalizeBigfontBodyGlyph(shape.bbox, size)) {
+    shape = shape.normalizeToOrigin(true);
+  } else if (isBigfontTopPunctuation(shape.bbox, size)) {
+    const capHeight = scaledCapHeight(content, size);
+    const shiftY = capHeight - shape.bbox.maxY;
+    if (Math.abs(shiftY) > LAYOUT_BASELINE_EPSILON) {
+      shape = shape.offset(new Point(0, shiftY), true);
+    }
+  }
+
+  return shape;
+}
+
+function alignVerticalNegativeYGlyph(
+  shape: ShxShape,
+  content: ShxFontContentData,
+  size: number
+): ShxShape {
+  const { minY, maxY } = shape.bbox;
+
+  if (minY >= 0) {
+    if (isZeroHeightBaselineStroke(shape.bbox, content, size)) {
+      return centerInCapBand(shape, content, size);
+    }
+    if (isSmallCapPunctuation(shape.bbox, size)) {
+      return centerInCapBand(shape, content, size);
+    }
+    return shape;
+  }
+
+  const band = verticalBaselineBand(content, size);
+  if (maxY > band) {
+    return shape;
+  }
+
+  if (maxY < -band) {
+    const { height, baseUp } = content;
+    if (height <= 0) {
+      return shape;
+    }
+    return shape.offset(new Point(0, size * (baseUp / height)), true);
+  }
+
+  return shape.normalizeToOrigin(true);
+}
+
+/**
+ * Applies font-type-specific baseline alignment to scaled SHX geometry for text layout.
+ *
+ * Raw {@link ShxFont.getCharShape} output keeps encoded coordinates from the SHX file;
+ * this function repositions glyphs so mixed-font lines share a common baseline and
+ * punctuation renders correctly without shrinking horizontal advance.
+ */
+export function alignShxGlyphForLayout(shape: ShxShape, fontData: ShxFontData, size: number): ShxShape {
+  const fontType = fontData.header.fontType;
+  const content = fontData.content;
+
+  if (fontType === ShxFontType.BIGFONT) {
+    shape = alignBigfontGlyph(shape, content, size);
+  } else if (usesVerticalNegativeYAlignment(fontType, content)) {
+    shape = alignVerticalNegativeYGlyph(shape, content, size);
+  }
+
+  if (fontType === ShxFontType.UNIFONT) {
+    shape = extendNarrowGlyphAdvance(shape, size);
+  }
+
+  return shape;
+}
+
+/**
+ * Scaled font metrics derived from shape #0 (`baseUp`, `baseDown`, `height`, `width`).
+ *
+ * These values describe the font cell at a target render size. Text renderers use them
+ * to align mixed-font lines on a shared baseline without modifying individual glyphs.
+ */
+export interface ShxFontMetrics {
+  /** Target render size (font cell height in drawing units) */
+  size: number;
+  /** Distance from the baseline to the top of the cap band */
+  capHeight: number;
+  /** Distance from the baseline downward into the descender band */
+  descenderHeight: number;
+  /** Scaled cell width */
+  cellWidth: number;
+  /** Sum of cap and descender bands (`capHeight + descenderHeight`) */
+  totalHeight: number;
+}
 
 /**
  * Represents a SHX font and provides methods to parse and render its characters.
@@ -98,13 +329,37 @@ export class ShxFont {
   }
 
   /**
+   * Returns scaled font metrics for a target render size.
+   * @param size - Target font size in drawing units
+   */
+  getFontMetrics(size: number): ShxFontMetrics {
+    return computeFontMetrics(this.fontData.content, size);
+  }
+
+  /**
+   * Returns a layout-ready glyph: scaled geometry with baseline alignment applied.
+   *
+   * Prefer this over {@link ShxFont.getCharShape} when placing text for display.
+   *
+   * @param code - The character code to get the shape for
+   * @param size - The desired font size
+   */
+  getLayoutCharShape(code: number, size: number): ShxShape | undefined {
+    const raw = this.getCharShape(code, size);
+    if (!raw) {
+      return undefined;
+    }
+    return alignShxGlyphForLayout(raw, this.fontData, size);
+  }
+
+  /**
    * Gets the shape data for a named shape at a given font size.
    * Shape names are matched case-insensitively.
    * @param name - The shape name to get the shape for
    * @param size - The desired font size
    * @returns The shape data for the named shape, or undefined if it is not found in the font
    */
-  getShapeByName(name: string, size: number) {
+  getShapeByName(name: string, size: number): ShxShape | undefined {
     const code = this.getShapeCode(name);
     if (code === undefined) {
       return undefined;
@@ -113,36 +368,18 @@ export class ShxFont {
   }
 
   /**
-   * Gets the shape data for a specific character at a given font size.
+   * Gets the scaled shape geometry for a character code.
+   *
+   * Returns the glyph as encoded in the SHX file, scaled to `size`. Vertical placement
+   * and mixed-font baseline alignment are the responsibility of the text renderer;
+   * see the `textLayout` module and {@link ShxFont.getFontMetrics}.
+   *
    * @param code - The character code to get the shape for
    * @param size - The desired font size
    * @returns The shape data for the character, or undefined if the character is not found in the font
    */
-  public getCharShape(code: number, size: number) {
-    let shape = this.shapeParser.getCharShape(code, size);
-    if (!shape) {
-      return undefined;
-    }
-
-    const fontType = this.fontData.header.fontType;
-
-    if (fontType === ShxFontType.BIGFONT) {
-      // Normalize baseline-aligned and mid-cell body glyphs to the origin.
-      // Top/center punctuation (e.g. “一”, quotation marks) sit in the upper
-      // half of the cell and must keep their vertical position.
-      if (shape.bbox.minY <= size * 0.5) {
-        shape = shape.normalizeToOrigin(true);
-      }
-    } else if (fontType === ShxFontType.UNIFONT) {
-      // Some unifont files (e.g. tssdeng.shx) encode body strokes in negative Y
-      // with maxY on the baseline. Shift to cell-bottom origin so mixed
-      // bigfont + unifont lines share minY = 0 as the bottom edge.
-      if (shape.bbox.minY < 0 && shape.bbox.maxY <= UNIFONT_BASELINE_EPSILON) {
-        shape = shape.normalizeToOrigin(true);
-      }
-    }
-
-    return shape;
+  public getCharShape(code: number, size: number): ShxShape | undefined {
+    return this.shapeParser.getCharShape(code, size);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './font';
 export * from './fontData';
+export * from './textLayout';
 export * from './contentParser';
 export * from './point';
 export * from './shape';

--- a/src/shapeParser.ts
+++ b/src/shapeParser.ts
@@ -539,7 +539,9 @@ export class ShxShapeParser {
           state.currentPolyline.push(state.currentPoint.clone());
         }
       } else {
-        // BIGFONT parent: do not inherit subshape endpoint or pen stroke.
+        // BIGFONT parent: do not inherit subshape endpoint or pen stroke for
+        // drawing primitives (typically #1). Terminal advance primitive #2
+        // (hztxt-style `7,2,0` suffix) defines the pen-up vector / cell width.
         shape = this.getScaledSubshapeAtInsertPoint(
           subCode,
           width,
@@ -548,6 +550,12 @@ export class ShxShapeParser {
         );
         if (shape) {
           state.polylines.push(...shape.polylines.slice());
+          if (subCode === 2 && shape.lastPoint) {
+            const cellWidth = shape.lastPoint.x - origin.x;
+            if (cellWidth > state.currentPoint.x) {
+              state.currentPoint.x = cellWidth;
+            }
+          }
         }
         state.currentPolyline = [];
       }
@@ -896,10 +904,15 @@ export class ShxShapeParser {
       this.fontData.header.fontType === ShxFontType.BIGFONT
         ? undefined
         : height / this.fontData.content.baseUp;
+    const hasDrawableGeometry = baseShape.polylines.some(line => line.length > 0);
     const scaled =
       subshapeScale !== undefined
         ? this.scaleShapeByFactor(baseShape, subshapeScale)
-        : this.scaleShapeByHeightAndWidth(baseShape.normalizeToOrigin(true), height, width);
+        : this.scaleShapeByHeightAndWidth(
+            hasDrawableGeometry ? baseShape.normalizeToOrigin(true) : baseShape,
+            height,
+            width
+          );
     return scaled.offset(insertPoint, false);
   }
 

--- a/src/textLayout.ts
+++ b/src/textLayout.ts
@@ -1,0 +1,106 @@
+import { computeFontMetrics, ShxFont } from './font';
+import { ShxFontData, ShxFontType } from './fontData';
+import { Point } from './point';
+import { ShxShape } from './shape';
+
+const ADVANCE_EPSILON = 1e-6;
+
+/** A glyph positioned on a text line. */
+export interface PlacedGlyph {
+  /** Scaled glyph geometry translated to the line position */
+  shape: ShxShape;
+  /** Left edge x coordinate (baseline origin for this glyph) */
+  x: number;
+}
+
+/** One character in a horizontal text run. */
+export interface TextRunGlyph {
+  font: ShxFont;
+  code: number;
+  size: number;
+}
+
+/**
+ * Returns the horizontal advance width of a scaled glyph.
+ *
+ * Uses the pen-up vector from the SHX shape definition when present; otherwise falls
+ * back to the glyph bounding box width.
+ */
+export function getAdvanceWidth(shape: ShxShape): number {
+  if (shape.lastPoint) {
+    return shape.lastPoint.x;
+  }
+  const { minX, maxX } = shape.bbox;
+  return maxX - minX;
+}
+
+/**
+ * Resolves the horizontal advance for a layout-ready glyph.
+ *
+ * @param shape - Scaled glyph geometry, typically from {@link ShxFont.getLayoutCharShape}
+ * @param fontData - Parsed font header and content
+ * @param size - Target font size in drawing units
+ */
+export function resolveAdvanceWidth(shape: ShxShape, fontData: ShxFontData, size: number): number {
+  const scaledCellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+  const bboxWidth = shape.bbox.maxX - shape.bbox.minX;
+  const penAdvance = getAdvanceWidth(shape);
+  const bboxMaxX = shape.bbox.maxX;
+  const fontType = fontData.header.fontType;
+
+  if (bboxMaxX < scaledCellWidth * 0.25) {
+    return penAdvance;
+  }
+
+  if (fontType === ShxFontType.BIGFONT) {
+    return Math.max(bboxWidth, penAdvance, scaledCellWidth);
+  }
+
+  if (fontType === ShxFontType.UNIFONT) {
+    const inkExtent = Math.max(bboxWidth, bboxMaxX);
+    let advance = Math.max(penAdvance, inkExtent);
+    if (inkExtent > penAdvance + ADVANCE_EPSILON) {
+      advance = Math.max(advance, scaledCellWidth);
+    } else if (bboxMaxX < scaledCellWidth * 0.25) {
+      advance = Math.max(penAdvance, inkExtent);
+    }
+    return advance;
+  }
+
+  return penAdvance > 0 ? penAdvance : bboxWidth;
+}
+
+/**
+ * Translates a glyph so its font baseline sits at `(x, baselineY)`.
+ *
+ * Glyphs keep their encoded vertical coordinates from the SHX file; the baseline is
+ * y = 0 in font space per the AutoCAD shape-font specification.
+ */
+export function placeGlyphOnBaseline(shape: ShxShape, x: number, baselineY = 0): ShxShape {
+  return shape.offset(new Point(x, baselineY), true);
+}
+
+/**
+ * Lays out glyphs horizontally on a shared baseline using each font's native coordinates.
+ *
+ * @param glyphs - Characters to place left-to-right
+ * @param baselineY - Shared baseline y coordinate in drawing units
+ */
+export function layoutTextRun(glyphs: TextRunGlyph[], baselineY = 0): PlacedGlyph[] {
+  let cursorX = 0;
+  const placed: PlacedGlyph[] = [];
+
+  for (const { font, code, size } of glyphs) {
+    const shape = font.getLayoutCharShape(code, size);
+    if (!shape) {
+      continue;
+    }
+    placed.push({
+      shape: placeGlyphOnBaseline(shape, cursorX, baselineY),
+      x: cursorX,
+    });
+    cursorX += resolveAdvanceWidth(shape, font.fontData, size);
+  }
+
+  return placed;
+}


### PR DESCRIPTION
## Summary

- **Architecture**: `getCharShape()` now returns scaled SHX geometry without post-processing. Baseline alignment lives in `alignShxGlyphForLayout()` / `getLayoutCharShape()`, and horizontal spacing in the new `textLayout` module (`layoutTextRun`, `resolveAdvanceWidth`, `getFontMetrics`).
- **Parser fix**: BIGFONT terminal advance primitive `#2` (hztxt-style `7,2,0` suffix) is applied to the pen position so full cell width is preserved after alignment.
- **Tests**: Integration tests for hztxt punctuation spacing, mixed-font baseline alignment, and unit tests for layout helpers.

## Breaking change

Callers that relied on `getCharShape()` applying baseline normalization should switch to `getLayoutCharShape()` for text rendering.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm test` (171 tests, coverage thresholds met)