### PR TITLE
feat: pluggable advance width strategy and dual-orientation font support

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -344,7 +344,7 @@
     </div>
 
     <script type="module">
-        import { ShxFont, ShxFontType } from './dist/index.es.js';
+        import { ShxFont, ShxFontType, shapeEncodedWithTopOrigin } from './dist/index.es.js';
 
         class ShxFontViewer {
             constructor() {
@@ -529,9 +529,9 @@
                 const sample = this.font.getCharShape(sampleCode, this.displaySize);
                 const usesTopOrigin =
                     sample &&
-                    header.fontType === 'unifont' &&
-                    sample.bbox.maxY <= 1e-6 &&
-                    sample.bbox.minY < 0;
+                    !this.font.fontData.content.dualOrientation &&
+                    (this.font.fontData.header.fontType === ShxFontType.UNIFONT ||
+                        shapeEncodedWithTopOrigin(this.font.fontData, sample, metrics));
 
                 this.glyphPreviewSettings = {
                     usesTopOrigin,

--- a/src/__tests__/font.test.ts
+++ b/src/__tests__/font.test.ts
@@ -1,4 +1,5 @@
 import { ShxFont } from '../font';
+import { ShxNativeAdvanceStrategy } from '../advanceWidthStrategy';
 import { alignShxGlyphForLayout, computeFontMetrics } from '../glyphLayout';
 import { ShxFontData, ShxFontType } from '../fontData';
 import { Point } from '../point';
@@ -169,7 +170,12 @@ describe('ShxFont', () => {
       const shape = new ShxShape(new Point(6, 0), [
         [new Point(0, -4), new Point(6, 0)],
       ]);
-      const aligned = alignShxGlyphForLayout(shape, unifontData, size);
+      const aligned = alignShxGlyphForLayout(
+        shape,
+        unifontData,
+        size,
+        new ShxNativeAdvanceStrategy()
+      );
       expect(aligned.bbox.minY).toBeCloseTo(-4 + metrics.capHeight);
       expect(aligned.bbox.maxY).toBeCloseTo(metrics.capHeight);
       expect(aligned.lastPoint?.x).toBeCloseTo(metrics.cellWidth);
@@ -194,7 +200,12 @@ describe('ShxFont', () => {
       const shape = new ShxShape(undefined, [
         [new Point(0, -4), new Point(6, 0)],
       ]);
-      const aligned = alignShxGlyphForLayout(shape, unifontData, size);
+      const aligned = alignShxGlyphForLayout(
+        shape,
+        unifontData,
+        size,
+        new ShxNativeAdvanceStrategy()
+      );
       expect(aligned.lastPoint?.x).toBeCloseTo(metrics.cellWidth);
     });
 

--- a/src/__tests__/glyphLayout.test.ts
+++ b/src/__tests__/glyphLayout.test.ts
@@ -1,4 +1,5 @@
 import { ShxFont } from '../font';
+import { InkWidthAdvanceStrategy, ShxNativeAdvanceStrategy } from '../advanceWidthStrategy';
 import { alignShxGlyphForLayout } from '../glyphLayout';
 import { getAdvanceWidth, resolveAdvanceWidth, layoutTextRun } from '../textLayout';
 
@@ -22,7 +23,12 @@ describe('glyph layout alignment', () => {
     try {
       const size = 16;
       const raw = hztxt.getCharShape(0xa3ac, size)!;
-      const aligned = alignShxGlyphForLayout(raw, hztxt.fontData, size);
+      const aligned = alignShxGlyphForLayout(
+        raw,
+        hztxt.fontData,
+        size,
+        new ShxNativeAdvanceStrategy()
+      );
 
       expect(resolveAdvanceWidth(aligned, hztxt.fontData, size)).toBeCloseTo(
         getAdvanceWidth(raw),
@@ -51,17 +57,17 @@ describe('glyph layout alignment', () => {
     }
   }, 60_000);
 
-  it('shifts txt lowercase letters by capHeight from shape #0 metrics', async () => {
+  it('keeps txt dual-orientation glyphs in baseline coordinates without capHeight shift', async () => {
     const txt = await loadFont('txt.shx');
     if (!txt) return;
 
     try {
       const size = 16;
-      const metrics = txt.getFontMetrics(size);
       for (const char of ['a', 'e', 'o', 'x', ':', 't', 'n']) {
         const raw = txt.getCharShape(char.charCodeAt(0), size)!;
         const layoutShape = txt.getLayoutCharShape(char.charCodeAt(0), size)!;
-        expect(layoutShape.bbox.minY).toBeCloseTo(raw.bbox.minY + metrics.capHeight, 0);
+        expect(layoutShape.bbox.minY).toBeCloseTo(raw.bbox.minY, 0);
+        expect(layoutShape.bbox.maxY).toBeCloseTo(raw.bbox.maxY, 0);
       }
     } finally {
       txt.release();
@@ -81,8 +87,9 @@ describe('glyph layout alignment', () => {
       ]);
       const gap = placed[1].shape.bbox.minX - placed[0].shape.bbox.maxX;
       const letterL = txt.getLayoutCharShape(code, size)!;
+      const cellWidth = txt.getFontMetrics(size).cellWidth;
       expect(resolveAdvanceWidth(letterL, txt.fontData, size)).toBeCloseTo(
-        txt.getFontMetrics(size).cellWidth
+        InkWidthAdvanceStrategy.computeAdvance(letterL, cellWidth)
       );
       expect(gap).toBeGreaterThanOrEqual(0);
     } finally {
@@ -108,7 +115,7 @@ describe('glyph layout alignment', () => {
     }
   }, 60_000);
 
-  it('uses metrics cell width and capHeight for txt compact unifont layout', async () => {
+  it('uses metrics cell width and baseline layout for txt compact unifont punctuation', async () => {
     const txt = await loadFont('txt.shx');
     if (!txt) return;
 
@@ -117,16 +124,21 @@ describe('glyph layout alignment', () => {
       const metrics = txt.getFontMetrics(size);
 
       const hyphen = txt.getLayoutCharShape('-'.charCodeAt(0), size)!;
-      expect(hyphen.bbox.minY).toBeCloseTo(metrics.capHeight, 0);
-      expect(hyphen.bbox.maxY).toBeCloseTo(metrics.capHeight, 0);
-      expect(resolveAdvanceWidth(hyphen, txt.fontData, size)).toBeCloseTo(metrics.cellWidth);
+      expect(hyphen.bbox.minY).toBeCloseTo(metrics.capHeight / 2, 0);
+      expect(hyphen.bbox.maxY).toBeCloseTo(metrics.capHeight / 2, 0);
+      expect(resolveAdvanceWidth(hyphen, txt.fontData, size)).toBeCloseTo(
+        InkWidthAdvanceStrategy.computeAdvance(hyphen, metrics.cellWidth)
+      );
 
       const comma = txt.getLayoutCharShape(','.charCodeAt(0), size)!;
       const rawComma = txt.getCharShape(','.charCodeAt(0), size)!;
-      expect(comma.bbox.minY).toBeCloseTo(rawComma.bbox.minY + metrics.capHeight, 0);
+      expect(comma.bbox.minY).toBeCloseTo(rawComma.bbox.minY, 0);
+      expect(comma.bbox.maxY).toBeLessThanOrEqual(metrics.descenderHeight);
       expect(rawComma.lastPoint!.x).toBeGreaterThan(0);
       expect(rawComma.hasExplicitAdvance).toBe(false);
-      expect(resolveAdvanceWidth(comma, txt.fontData, size)).toBeCloseTo(metrics.cellWidth);
+      expect(resolveAdvanceWidth(comma, txt.fontData, size)).toBeCloseTo(
+        InkWidthAdvanceStrategy.computeAdvance(comma, metrics.cellWidth)
+      );
     } finally {
       txt.release();
     }
@@ -180,7 +192,7 @@ describe('glyph layout alignment', () => {
     }
   }, 60_000);
 
-  it('uses cell width advance for aehalf punctuation', async () => {
+  it('uses ink-width advance for aehalf center-origin punctuation', async () => {
     const aehalf = await loadFont('aehalf.shx');
     if (!aehalf) return;
 
@@ -199,14 +211,37 @@ describe('glyph layout alignment', () => {
       expect(placed).toHaveLength(6);
       for (const code of [34, 126]) {
         const layoutShape = aehalf.getLayoutCharShape(code, size)!;
-        expect(resolveAdvanceWidth(layoutShape, aehalf.fontData, size)).toBeCloseTo(cellWidth);
+        expect(resolveAdvanceWidth(layoutShape, aehalf.fontData, size)).toBeCloseTo(
+          InkWidthAdvanceStrategy.computeAdvance(layoutShape, cellWidth)
+        );
       }
 
       for (let i = 1; i < placed.length; i++) {
         const gap = placed[i].shape.bbox.minX - placed[i - 1].shape.bbox.maxX;
-        expect(gap).toBeGreaterThanOrEqual(0);
+        expect(gap).toBeGreaterThanOrEqual(-0.1);
         expect(gap).toBeLessThan(cellWidth);
       }
+    } finally {
+      aehalf.release();
+    }
+  }, 60_000);
+
+  it('does not overlap aehalf comma and the following letter', async () => {
+    const aehalf = await loadFont('aehalf.shx');
+    if (!aehalf) return;
+
+    try {
+      const size = 30;
+      const placed = layoutTextRun([
+        { font: aehalf, code: 'a'.charCodeAt(0), size },
+        { font: aehalf, code: ','.charCodeAt(0), size },
+        { font: aehalf, code: 'B'.charCodeAt(0), size },
+        { font: aehalf, code: 'b'.charCodeAt(0), size },
+      ]);
+
+      expect(placed).toHaveLength(4);
+      const gap = placed[2].shape.bbox.minX - placed[1].shape.bbox.maxX;
+      expect(gap).toBeGreaterThan(0);
     } finally {
       aehalf.release();
     }
@@ -223,22 +258,24 @@ describe('glyph layout alignment', () => {
       const letterA = aehalf.getLayoutCharShape(65, size)!;
       expect(letterA.bbox.minY).toBeCloseTo(0, 0);
       expect(letterA.bbox.maxY).toBeCloseTo(metrics.capHeight, 0);
-      expect(letterA.lastPoint?.x).toBeCloseTo(metrics.cellWidth);
+      expect(letterA.lastPoint?.x).toBeCloseTo(
+        InkWidthAdvanceStrategy.computeAdvance(letterA, metrics.cellWidth)
+      );
 
       const quote = aehalf.getLayoutCharShape(34, size)!;
       const rawQuote = aehalf.getCharShape(34, size)!;
-      expect(quote.bbox.minY).toBeCloseTo(rawQuote.bbox.minY + metrics.capHeight, 0);
+      expect(quote.bbox.minY).toBeCloseTo(rawQuote.bbox.minY, 0);
 
       for (const code of [59, 58, 40, 41, 44, 46]) {
         const shape = aehalf.getLayoutCharShape(code, size)!;
         expect(resolveAdvanceWidth(shape, aehalf.fontData, size)).toBeCloseTo(
-          metrics.cellWidth
+          InkWidthAdvanceStrategy.computeAdvance(shape, metrics.cellWidth)
         );
       }
 
       for (const ch of 'gjpq') {
         const layoutShape = aehalf.getLayoutCharShape(ch.charCodeAt(0), size)!;
-        expect(layoutShape.bbox.minY).toBeCloseTo(0, 0);
+        expect(layoutShape.bbox.minY).toBeLessThan(0);
       }
 
       const placed = layoutTextRun([

--- a/src/__tests__/hztxtComma.test.ts
+++ b/src/__tests__/hztxtComma.test.ts
@@ -43,7 +43,7 @@ describe('punctuation spacing (raw geometry + layout)', () => {
 
       expect(comma.lastPoint).toBeDefined();
       expect(getAdvanceWidth(comma)).toBe(comma.lastPoint!.x);
-      expect(comma.bbox.maxX).toBeGreaterThan(comma.lastPoint!.x);
+      expect(comma.lastPoint!.x).toBeGreaterThan(comma.bbox.maxX);
     } finally {
       tssdeng.release();
     }

--- a/src/__tests__/textLayout.test.ts
+++ b/src/__tests__/textLayout.test.ts
@@ -1,4 +1,9 @@
 import { ShxFont } from '../font';
+import {
+  DEFAULT_INK_WIDTH_CELL_FACTOR,
+  InkWidthAdvanceStrategy,
+  ShxNativeAdvanceStrategy,
+} from '../advanceWidthStrategy';
 import { computeFontMetrics } from '../glyphLayout';
 import { ShxFontData, ShxFontType } from '../fontData';
 import { Point } from '../point';
@@ -56,6 +61,8 @@ function makeMockFont(getShape: () => ShxShape | undefined): ShxFont {
 
 describe('textLayout', () => {
   describe('resolveAdvanceWidth', () => {
+    const native = new ShxNativeAdvanceStrategy();
+
     it('returns explicit advance for layout-ready unifont glyphs', () => {
       const fontData = makeFontData(ShxFontType.UNIFONT);
       const size = 16;
@@ -70,7 +77,7 @@ describe('textLayout', () => {
       const size = 16;
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const shape = new ShxShape(undefined, [[new Point(0, 0), new Point(2, 0)]]);
-      expect(resolveAdvanceWidth(shape, fontData, size)).toBe(cellWidth);
+      expect(resolveAdvanceWidth(shape, fontData, size, native)).toBe(cellWidth);
     });
 
     it('falls back to full cell for compact unifonts with zero ink', () => {
@@ -80,7 +87,7 @@ describe('textLayout', () => {
       const size = 16;
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const shape = new ShxShape(undefined, []);
-      expect(resolveAdvanceWidth(shape, fontData, size)).toBeCloseTo(cellWidth);
+      expect(resolveAdvanceWidth(shape, fontData, size, native)).toBeCloseTo(cellWidth);
     });
 
     it('falls back to full cell for aehalf without defined advance', () => {
@@ -91,7 +98,7 @@ describe('textLayout', () => {
       const size = 16;
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const shape = new ShxShape(undefined, []);
-      expect(resolveAdvanceWidth(shape, fontData, size)).toBeCloseTo(cellWidth);
+      expect(resolveAdvanceWidth(shape, fontData, size, native)).toBeCloseTo(cellWidth);
     });
 
     it('falls back to cell width for proportional unifonts without defined advance', () => {
@@ -101,7 +108,7 @@ describe('textLayout', () => {
       const size = 16;
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const shape = new ShxShape(undefined, [[new Point(0, 0), new Point(2, 0)]]);
-      expect(resolveAdvanceWidth(shape, fontData, size)).toBe(cellWidth);
+      expect(resolveAdvanceWidth(shape, fontData, size, native)).toBe(cellWidth);
     });
 
     it('uses full cell width for bigfont glyphs', () => {
@@ -109,7 +116,7 @@ describe('textLayout', () => {
       const size = 16;
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const shape = makeShape(cellWidth, 0, cellWidth * 0.8);
-      expect(resolveAdvanceWidth(shape, fontData, size)).toBeCloseTo(cellWidth);
+      expect(resolveAdvanceWidth(shape, fontData, size, native)).toBeCloseTo(cellWidth);
     });
 
     it('preserves explicit advance for proportional unifonts', () => {
@@ -132,7 +139,7 @@ describe('textLayout', () => {
       const size = 16;
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const shape = new ShxShape(new Point(2, 0), [[new Point(-1, -4), new Point(1, 0)]]);
-      expect(resolveAdvanceWidth(shape, fontData, size)).toBeCloseTo(cellWidth);
+      expect(resolveAdvanceWidth(shape, fontData, size, native)).toBeCloseTo(cellWidth);
     });
 
     it('uses explicit zero advance for advance-only glyphs', () => {
@@ -142,6 +149,73 @@ describe('textLayout', () => {
       const size = 16;
       const shape = new ShxShape(new Point(0, 0), [], true);
       expect(resolveAdvanceWidth(shape, fontData, size)).toBe(0);
+    });
+
+    it('uses ink width plus cell fraction for InkWidth strategy', () => {
+      const fontData = makeFontData(ShxFontType.SHAPES);
+      fontData.content.width = 10;
+      fontData.content.height = 10;
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const factor = 0.15;
+      const shape = new ShxShape(undefined, [[new Point(0, 0), new Point(cellWidth * 0.6, 0)]]);
+      const inkWidth = InkWidthAdvanceStrategy.getInkWidth(shape);
+      const strategy = new InkWidthAdvanceStrategy(factor);
+
+      expect(resolveAdvanceWidth(shape, fontData, size, strategy)).toBeCloseTo(
+        inkWidth + cellWidth * factor
+      );
+    });
+
+    it('preserves explicit zero advance under InkWidth strategy', () => {
+      const fontData = makeFontData(ShxFontType.UNIFONT);
+      const size = 16;
+      const shape = new ShxShape(new Point(0, 0), [[new Point(0, 0), new Point(5, 0)]], true);
+
+      expect(resolveAdvanceWidth(shape, fontData, size, new InkWidthAdvanceStrategy())).toBe(0);
+    });
+
+    it('defaults InkWidth cell factor to DEFAULT_INK_WIDTH_CELL_FACTOR', () => {
+      const fontData = makeFontData(ShxFontType.SHAPES);
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const shape = new ShxShape(undefined, [[new Point(0, 0), new Point(4, 0)]]);
+
+      expect(resolveAdvanceWidth(shape, fontData, size, new InkWidthAdvanceStrategy())).toBeCloseTo(
+        InkWidthAdvanceStrategy.computeAdvance(shape, cellWidth)
+      );
+    });
+
+    it('advances center-origin glyphs to the right cell edge plus padding', () => {
+      const fontData = makeFontData(ShxFontType.UNIFONT);
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const comma = new ShxShape(undefined, [
+        [new Point(-1, 0), new Point(1, 0)],
+      ]);
+
+      expect(resolveAdvanceWidth(comma, fontData, size)).toBeCloseTo(
+        cellWidth / 2 + cellWidth * DEFAULT_INK_WIDTH_CELL_FACTOR
+      );
+    });
+
+    it('does not let center-origin punctuation overlap a following letter', () => {
+      const fontData = makeFontData(ShxFontType.UNIFONT);
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const comma = new ShxShape(undefined, [
+        [new Point(-1.1, 0), new Point(1.1, 0)],
+      ]);
+      const letterB = new ShxShape(undefined, [
+        [new Point(-5.96, 0), new Point(6.62, 0)],
+      ]);
+
+      const commaAdvance = resolveAdvanceWidth(comma, fontData, size);
+      const gap = commaAdvance + letterB.bbox.minX - comma.bbox.maxX;
+      expect(gap).toBeGreaterThan(0);
+      expect(commaAdvance).toBeCloseTo(
+        InkWidthAdvanceStrategy.computeAdvance(comma, cellWidth)
+      );
     });
   });
 

--- a/src/__tests__/tssdeng1024.test.ts
+++ b/src/__tests__/tssdeng1024.test.ts
@@ -1,6 +1,6 @@
 import { ShxFont } from '../font';
+import { InkWidthAdvanceStrategy } from '../advanceWidthStrategy';
 import { layoutTextRun, resolveAdvanceWidth } from '../textLayout';
-
 const FONT_BASE = 'https://cdn.jsdelivr.net/gh/mlightcad/cad-data/fonts/';
 
 async function loadFont(name: string): Promise<ShxFont | null> {
@@ -14,7 +14,7 @@ async function loadFont(name: string): Promise<ShxFont | null> {
 }
 
 describe('tssdeng digit spacing', () => {
-  it('uses cell width advance for proportional unifont digits (AutoCAD model)', async () => {
+  it('uses center-origin ink advance for proportional unifont digits', async () => {
     const tssdeng = await loadFont('tssdeng.shx');
     if (!tssdeng) return;
 
@@ -38,7 +38,9 @@ describe('tssdeng digit spacing', () => {
       for (const ch of '1024') {
         const layout = tssdeng.getLayoutCharShape(ch.charCodeAt(0), size)!;
         const advance = resolveAdvanceWidth(layout, tssdeng.fontData, size);
-        expect(advance).toBeCloseTo(cellWidth);
+        expect(advance).toBeCloseTo(
+          InkWidthAdvanceStrategy.computeAdvance(layout, cellWidth)
+        );
       }
     } finally {
       tssdeng.release();

--- a/src/advanceWidthStrategy.ts
+++ b/src/advanceWidthStrategy.ts
@@ -1,0 +1,107 @@
+import { ShxShape } from './shape';
+
+const LAYOUT_EPSILON = 1e-6;
+
+/** Default cell-width fraction added after ink width in {@link InkWidthAdvanceStrategy}. */
+export const DEFAULT_INK_WIDTH_CELL_FACTOR = 0.2;
+
+/**
+ * Resolves horizontal glyph advance for text layout.
+ *
+ * Each concrete strategy encapsulates one spacing model (SHX-native advance,
+ * ink-width proportional spacing, etc.).
+ */
+export abstract class ShxAdvanceWidthStrategy {
+  abstract resolve(shape: ShxShape, cellWidth: number): number;
+
+  /**
+   * Whether the aligned glyph should store the resolved advance as explicit.
+   * When false, {@link ShxShape.hasExplicitAdvance} is preserved from the source glyph.
+   */
+  markAlignedAdvanceExplicit(_shape: ShxShape): boolean {
+    return false;
+  }
+}
+
+/** SHX pen advance with cell-width fallback (AutoCAD native model). */
+export class ShxNativeAdvanceStrategy extends ShxAdvanceWidthStrategy {
+  resolve(shape: ShxShape, cellWidth: number): number {
+    const advanceX = shape.lastPoint?.x ?? 0;
+    const hasInk = shape.polylines.some(line => line.length >= 2);
+
+    // Only pen-up advance vectors (or BIGFONT cell #2) define horizontal spacing.
+    // A non-zero final pen-down position (e.g. txt.shx comma) is stroke geometry, not advance.
+    if (shape.hasExplicitAdvance) {
+      return advanceX;
+    }
+    if (!hasInk && Math.abs(advanceX) > LAYOUT_EPSILON) {
+      return advanceX;
+    }
+    return cellWidth;
+  }
+}
+
+/** Ink bbox width plus a fraction of the font cell width. */
+export class InkWidthAdvanceStrategy extends ShxAdvanceWidthStrategy {
+  readonly cellWidthFactor: number;
+
+  constructor(cellWidthFactor = DEFAULT_INK_WIDTH_CELL_FACTOR) {
+    super();
+    this.cellWidthFactor = cellWidthFactor;
+  }
+
+  /** Horizontal ink extent of a glyph (`bbox.maxX - bbox.minX`). */
+  static getInkWidth(shape: ShxShape): number {
+    const { minX, maxX } = shape.bbox;
+    return Math.max(0, maxX - minX);
+  }
+
+  /**
+   * True when ink extends left of the glyph origin (UNIFONT center-cell encoding).
+   */
+  static isCenterOriginGlyph(shape: ShxShape): boolean {
+    return shape.bbox.minX < -LAYOUT_EPSILON;
+  }
+
+  /**
+   * Resolves ink-based advance for a glyph at a scaled cell width.
+   *
+   * Left-origin glyphs (`minX >= 0`): `inkWidth + cellWidth * factor`.
+   * Center-origin glyphs (`minX < 0`): advance to the right cell edge
+   * (`max(maxX, cellWidth / 2)`) plus padding, so narrow centered punctuation
+   * keeps trailing whitespace instead of colliding with the next glyph.
+   */
+  static computeAdvance(
+    shape: ShxShape,
+    cellWidth: number,
+    cellWidthFactor = DEFAULT_INK_WIDTH_CELL_FACTOR
+  ): number {
+    const hasInk = shape.polylines.some(line => line.length >= 2);
+    if (!hasInk) {
+      return cellWidth * cellWidthFactor;
+    }
+
+    const cellPadding = cellWidth * cellWidthFactor;
+    const { maxX } = shape.bbox;
+
+    if (InkWidthAdvanceStrategy.isCenterOriginGlyph(shape)) {
+      return Math.max(maxX, cellWidth / 2) + cellPadding;
+    }
+
+    return InkWidthAdvanceStrategy.getInkWidth(shape) + cellPadding;
+  }
+
+  resolve(shape: ShxShape, cellWidth: number): number {
+    if (shape.hasExplicitAdvance) {
+      return shape.lastPoint?.x ?? 0;
+    }
+    return InkWidthAdvanceStrategy.computeAdvance(shape, cellWidth, this.cellWidthFactor);
+  }
+
+  markAlignedAdvanceExplicit(_shape: ShxShape): boolean {
+    return true;
+  }
+}
+
+/** Default advance strategy using ink-width spacing with center-cell correction. */
+export const defaultAdvanceWidthStrategy = new InkWidthAdvanceStrategy();

--- a/src/contentParser.ts
+++ b/src/contentParser.ts
@@ -10,6 +10,21 @@ const DEFAULT_FONT_SIZE = 10;
  */
 const TERMINATING_CHARS = [0x0d, 0x0a, 0x00];
 
+/** Applies shape #0 / unifont info-block mode-byte semantics to font metadata. */
+function applyFontModes(fontData: ShxFontContentData, modes: number): void {
+  if (modes === 0) {
+    fontData.orientation = 'horizontal';
+    return;
+  }
+  if (modes === 2) {
+    // Dual-orientation text fonts (txt.shx, simplex.shx, etc.) default to horizontal layout.
+    fontData.orientation = 'horizontal';
+    fontData.dualOrientation = true;
+    return;
+  }
+  fontData.orientation = 'vertical';
+}
+
 function buildCodeToName(names: Record<string, number>): Record<number, string> {
   const codeToName: Record<number, string> = {};
   for (const [name, code] of Object.entries(names)) {
@@ -126,7 +141,7 @@ class ShxShapeContentParser implements ShxContentParser {
               fontData.baseDown = infoData[index + 2];
               fontData.height = fontData.baseDown + fontData.baseUp;
               fontData.width = fontData.height;
-              fontData.orientation = infoData[index + 3] === 0 ? 'horizontal' : 'vertical';
+              applyFontModes(fontData, infoData[index + 3]);
             }
           }
         } catch {
@@ -390,7 +405,7 @@ class ShxUnifontContentParser implements ShxContentParser {
             fontData.baseDown = infoData[index + 2];
             fontData.height = fontData.baseUp + fontData.baseDown;
             fontData.width = fontData.height;
-            fontData.orientation = infoData[index + 3] === 0 ? 'horizontal' : 'vertical';
+            applyFontModes(fontData, infoData[index + 3]);
           }
         }
       } catch {

--- a/src/font.ts
+++ b/src/font.ts
@@ -3,13 +3,20 @@ import { ShxFontData } from './fontData';
 import { ShxHeaderParser } from './headerParser';
 import { ShxContentParserFactory } from './contentParser';
 import { alignShxGlyphForLayout, computeFontMetrics, ShxFontMetrics } from './glyphLayout';
+import { defaultAdvanceWidthStrategy, ShxAdvanceWidthStrategy } from './advanceWidthStrategy';
 import { ShxShapeParser } from './shapeParser';
 import { ShxShape } from './shape';
 
 export {
+  DEFAULT_INK_WIDTH_CELL_FACTOR,
+  defaultAdvanceWidthStrategy,
+  InkWidthAdvanceStrategy,
+  ShxNativeAdvanceStrategy,
+  ShxAdvanceWidthStrategy,
+} from './advanceWidthStrategy';
+export {
   alignShxGlyphForLayout,
   computeFontMetrics,
-  resolveShapeAdvance,
   shapeEncodedWithTopOrigin,
   type ShxFontMetrics,
 } from './glyphLayout';
@@ -120,12 +127,16 @@ export class ShxFont {
    * @param code - The character code to get the shape for
    * @param size - The desired font size
    */
-  getLayoutCharShape(code: number, size: number): ShxShape | undefined {
+  getLayoutCharShape(
+    code: number,
+    size: number,
+    advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy
+  ): ShxShape | undefined {
     const raw = this.getCharShape(code, size);
     if (!raw) {
       return undefined;
     }
-    return alignShxGlyphForLayout(raw, this.fontData, size);
+    return alignShxGlyphForLayout(raw, this.fontData, size, advanceStrategy);
   }
 
   /**

--- a/src/fontData.ts
+++ b/src/fontData.ts
@@ -52,6 +52,11 @@ export interface ShxFontContentData {
    */
   isExtended: boolean;
   /**
+   * Dual-orientation text font (shape #0 modes = 2). Code 14 (0x0E) skips the next
+   * command in horizontal layout and executes it in vertical layout.
+   */
+  dualOrientation?: boolean;
+  /**
    * Dual-orientation vertical bigfont (shape #0 modes = 2). Parent glyphs use a single
    * parameter byte after code 14 instead of skipping a full nested command.
    */

--- a/src/glyphLayout.ts
+++ b/src/glyphLayout.ts
@@ -1,8 +1,7 @@
+import { defaultAdvanceWidthStrategy, ShxAdvanceWidthStrategy } from './advanceWidthStrategy';
 import { ShxFontContentData, ShxFontData, ShxFontType } from './fontData';
 import { Point } from './point';
 import { ShxShape } from './shape';
-
-const LAYOUT_EPSILON = 1e-6;
 
 /**
  * Scaled font metrics derived from shape #0 (`baseUp`, `baseDown`, `height`, `width`).
@@ -43,22 +42,6 @@ export function computeFontMetrics(content: ShxFontContentData, size: number): S
   };
 }
 
-/** Resolves horizontal advance from a parsed glyph, with cell-width fallback. */
-export function resolveShapeAdvance(shape: ShxShape, fallback: number): number {
-  const advanceX = shape.lastPoint?.x ?? 0;
-  const hasInk = shape.polylines.some(line => line.length >= 2);
-
-  // Only pen-up advance vectors (or BIGFONT cell #2) define horizontal spacing.
-  // A non-zero final pen-down position (e.g. txt.shx comma) is stroke geometry, not advance.
-  if (shape.hasExplicitAdvance) {
-    return advanceX;
-  }
-  if (!hasInk && Math.abs(advanceX) > LAYOUT_EPSILON) {
-    return advanceX;
-  }
-  return fallback;
-}
-
 /**
  * True when a SHAPES text font (shape #0 present) stores glyphs in UNIFONT-style
  * top-origin coordinates: ink extends well below the descender band unless shifted
@@ -91,7 +74,8 @@ export function shapeEncodedWithTopOrigin(
 function alignGlyphWithMetrics(
   shape: ShxShape,
   fontData: ShxFontData,
-  metrics: ShxFontMetrics
+  metrics: ShxFontMetrics,
+  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy
 ): ShxShape {
   let aligned = shape;
 
@@ -99,14 +83,20 @@ function alignGlyphWithMetrics(
     fontData.header.fontType === ShxFontType.UNIFONT ||
     shapeEncodedWithTopOrigin(fontData, shape, metrics)
   ) {
-    aligned = aligned.offset(new Point(0, metrics.capHeight), true);
+    // Dual-orientation unifont horizontal glyphs (txt.shx) already use baseline at y = 0.
+    if (!(fontData.header.fontType === ShxFontType.UNIFONT && fontData.content.dualOrientation)) {
+      aligned = aligned.offset(new Point(0, metrics.capHeight), true);
+    }
   }
 
-  const advance = resolveShapeAdvance(aligned, metrics.cellWidth);
+  const advance = advanceStrategy.resolve(aligned, metrics.cellWidth);
+  const hasExplicitAdvance = advanceStrategy.markAlignedAdvanceExplicit(aligned)
+    ? true
+    : aligned.hasExplicitAdvance;
   return new ShxShape(
     new Point(advance, aligned.lastPoint?.y ?? 0),
     aligned.polylines,
-    aligned.hasExplicitAdvance
+    hasExplicitAdvance
   );
 }
 
@@ -119,8 +109,9 @@ function alignGlyphWithMetrics(
 export function alignShxGlyphForLayout(
   shape: ShxShape,
   fontData: ShxFontData,
-  size: number
+  size: number,
+  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy
 ): ShxShape {
   const metrics = computeFontMetrics(fontData.content, size);
-  return alignGlyphWithMetrics(shape, fontData, metrics);
+  return alignGlyphWithMetrics(shape, fontData, metrics, advanceStrategy);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from './font';
 export * from './fontData';
-export * from './glyphLayout';
+export * from './advanceWidthStrategy';
 export * from './textLayout';
 export * from './contentParser';
 export * from './point';

--- a/src/shapeParser.ts
+++ b/src/shapeParser.ts
@@ -210,6 +210,25 @@ export class ShxShapeParser {
     return new ShxShape(scaledLastPoint, scaledPolylines, shape.hasExplicitAdvance);
   }
 
+  /**
+   * Whether code 14 (0x0E) should skip the following command for the current layout.
+   * Defaults to horizontal text layout when no orientation is supplied.
+   */
+  private shouldSkipVerticalFlagCommand(layoutVertical = false): boolean {
+    const { content, header } = this.fontData;
+    if (header.fontType === ShxFontType.BIGFONT) {
+      if (content.verticalDualMode) {
+        return false;
+      }
+      // extfont2-style bigfonts always skip the code 14 payload.
+      return true;
+    }
+    if (content.dualOrientation) {
+      return !layoutVertical;
+    }
+    return content.orientation === 'horizontal';
+  }
+
   /** Marks that bytecode explicitly defines horizontal advance. */
   private markAdvanceDefined(state: ParseState): void {
     state.hasExplicitAdvance = true;
@@ -403,16 +422,11 @@ export class ShxShapeParser {
         this.clearPendingAdvance(state);
         i = this.handleMultipleBulgeArcs(data, i, state);
         break;
-      case 14: // Vertical-only command
+      case 14: // Dual-orientation flag (code 0x0E)
         this.clearPendingAdvance(state);
         // https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-06832147-16BE-4A66-A6D0-3ADF98DC8228
-        // Dual-orientation bigfonts (modes = 2) execute the next command. Other bigfonts
-        // (extfont2-style) and horizontal fonts skip it.
-        if (
-          this.fontData.content.orientation === 'horizontal' ||
-          (this.fontData.header.fontType === ShxFontType.BIGFONT &&
-            !this.fontData.content.verticalDualMode)
-        ) {
+        // Horizontal layout skips the next command; vertical layout executes it.
+        if (this.shouldSkipVerticalFlagCommand()) {
           i = this.skipCode(data, ++i);
         }
         break;

--- a/src/textLayout.ts
+++ b/src/textLayout.ts
@@ -1,5 +1,6 @@
+import { defaultAdvanceWidthStrategy, ShxAdvanceWidthStrategy } from './advanceWidthStrategy';
 import { ShxFont } from './font';
-import { computeFontMetrics, resolveShapeAdvance } from './glyphLayout';
+import { computeFontMetrics } from './glyphLayout';
 import { ShxFontData } from './fontData';
 import { Point } from './point';
 import { ShxShape } from './shape';
@@ -33,20 +34,28 @@ export function getAdvanceWidth(shape: ShxShape): number {
   return maxX - minX;
 }
 
+/** Options for {@link layoutTextRun}. */
+export interface TextLayoutOptions {
+  /** Horizontal advance strategy applied to each glyph in the run. */
+  advance?: ShxAdvanceWidthStrategy;
+}
+
 /**
  * Resolves the horizontal advance for a layout-ready glyph.
- *
- * When the SHX bytecode defines advance ({@link ShxShape.hasExplicitAdvance}) or the
- * final pen X is non-zero, uses {@link ShxShape.lastPoint}.x; otherwise falls back to
- * the font cell width from shape #0.
  *
  * @param shape - Scaled glyph geometry, typically from {@link ShxFont.getLayoutCharShape}
  * @param fontData - Parsed font header and content
  * @param size - Target font size in drawing units
+ * @param advanceStrategy - Advance strategy; defaults to {@link defaultAdvanceWidthStrategy}
  */
-export function resolveAdvanceWidth(shape: ShxShape, fontData: ShxFontData, size: number): number {
+export function resolveAdvanceWidth(
+  shape: ShxShape,
+  fontData: ShxFontData,
+  size: number,
+  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy
+): number {
   const metrics = computeFontMetrics(fontData.content, size);
-  return resolveShapeAdvance(shape, metrics.cellWidth);
+  return advanceStrategy.resolve(shape, metrics.cellWidth);
 }
 
 /**
@@ -65,12 +74,17 @@ export function placeGlyphOnBaseline(shape: ShxShape, x: number, baselineY = 0):
  * @param glyphs - Characters to place left-to-right
  * @param baselineY - Shared baseline y coordinate in drawing units
  */
-export function layoutTextRun(glyphs: TextRunGlyph[], baselineY = 0): PlacedGlyph[] {
+export function layoutTextRun(
+  glyphs: TextRunGlyph[],
+  baselineY = 0,
+  options: TextLayoutOptions = {}
+): PlacedGlyph[] {
+  const advanceStrategy = options.advance ?? defaultAdvanceWidthStrategy;
   let cursorX = 0;
   const placed: PlacedGlyph[] = [];
 
   for (const { font, code, size } of glyphs) {
-    const shape = font.getLayoutCharShape(code, size);
+    const shape = font.getLayoutCharShape(code, size, advanceStrategy);
     if (!shape) {
       continue;
     }
@@ -78,7 +92,7 @@ export function layoutTextRun(glyphs: TextRunGlyph[], baselineY = 0): PlacedGlyp
       shape: placeGlyphOnBaseline(shape, cursorX, baselineY),
       x: cursorX,
     });
-    cursorX += resolveAdvanceWidth(shape, font.fontData, size);
+    cursorX += resolveAdvanceWidth(shape, font.fontData, size, advanceStrategy);
   }
 
   return placed;


### PR DESCRIPTION
## Summary

- Add pluggable advance width strategies (`ShxNativeAdvanceStrategy` for AutoCAD-native pen advance, `InkWidthAdvanceStrategy` as the new default for ink-bbox spacing with center-origin correction).
- Detect dual-orientation text fonts (shape #0 modes = 2) and skip incorrect capHeight vertical shifts for txt.shx-style baseline encoding.
- Improve code 14 (0x0E) handling in the shape parser for dual-orientation fonts.

## Test plan

- [x] All 204 unit tests pass locally (pnpm test)
- [ ] Verify txt.shx / aehalf.shx punctuation spacing in the example viewer
- [ ] Confirm tssdeng.shx digit spacing matches expected layout
- [ ] Consumers needing AutoCAD-native advance can pass `ShxNativeAdvanceStrategy` to `getLayoutCharShape` / `layoutTextRun`