### PR TITLE
fix: use maxX for left-origin ink-width advance spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/shx-parser",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "A TypeScript library for parsing AutoCAD SHX font files",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/src/__tests__/glyphLayout.test.ts
+++ b/src/__tests__/glyphLayout.test.ts
@@ -226,6 +226,35 @@ describe('glyph layout alignment', () => {
     }
   }, 60_000);
 
+  it('keeps trailing padding for aehalf semicolon, colon, and digit one', async () => {
+    const aehalf = await loadFont('aehalf.shx');
+    if (!aehalf) return;
+
+    try {
+      const size = 30;
+      const cellWidth = aehalf.getFontMetrics(size).cellWidth;
+      const expectedGap = cellWidth * 0.2;
+
+      for (const [left, right] of [
+        [';', 'E'],
+        [':', 'D'],
+        ['1', '0'],
+      ] as const) {
+        const leftShape = aehalf.getLayoutCharShape(left.charCodeAt(0), size)!;
+        const rightShape = aehalf.getLayoutCharShape(right.charCodeAt(0), size)!;
+        const advance = resolveAdvanceWidth(leftShape, aehalf.fontData, size);
+        const gap = advance + rightShape.bbox.minX - leftShape.bbox.maxX;
+
+        expect(advance).toBeCloseTo(
+          InkWidthAdvanceStrategy.computeAdvance(leftShape, cellWidth)
+        );
+        expect(gap).toBeCloseTo(expectedGap, 0);
+      }
+    } finally {
+      aehalf.release();
+    }
+  }, 60_000);
+
   it('does not overlap aehalf comma and the following letter', async () => {
     const aehalf = await loadFont('aehalf.shx');
     if (!aehalf) return;

--- a/src/__tests__/textLayout.test.ts
+++ b/src/__tests__/textLayout.test.ts
@@ -151,7 +151,7 @@ describe('textLayout', () => {
       expect(resolveAdvanceWidth(shape, fontData, size)).toBe(0);
     });
 
-    it('uses ink width plus cell fraction for InkWidth strategy', () => {
+    it('uses right ink edge plus cell fraction for InkWidth strategy', () => {
       const fontData = makeFontData(ShxFontType.SHAPES);
       fontData.content.width = 10;
       fontData.content.height = 10;
@@ -159,12 +159,32 @@ describe('textLayout', () => {
       const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
       const factor = 0.15;
       const shape = new ShxShape(undefined, [[new Point(0, 0), new Point(cellWidth * 0.6, 0)]]);
-      const inkWidth = InkWidthAdvanceStrategy.getInkWidth(shape);
       const strategy = new InkWidthAdvanceStrategy(factor);
 
       expect(resolveAdvanceWidth(shape, fontData, size, strategy)).toBeCloseTo(
-        inkWidth + cellWidth * factor
+        shape.bbox.maxX + cellWidth * factor
       );
+    });
+
+    it('includes left offset when advancing left-origin punctuation', () => {
+      const fontData = makeFontData(ShxFontType.SHAPES);
+      const size = 16;
+      const cellWidth = computeFontMetrics(fontData.content, size).cellWidth;
+      const shape = new ShxShape(undefined, [
+        [new Point(4, 0), new Point(6, 0)],
+      ]);
+      const letter = new ShxShape(undefined, [
+        [new Point(0, 0), new Point(8, 0)],
+      ]);
+
+      const advance = resolveAdvanceWidth(shape, fontData, size);
+      const gap = advance + letter.bbox.minX - shape.bbox.maxX;
+
+      expect(advance).toBeCloseTo(
+        InkWidthAdvanceStrategy.computeAdvance(shape, cellWidth)
+      );
+      expect(advance).toBeCloseTo(shape.bbox.maxX + cellWidth * DEFAULT_INK_WIDTH_CELL_FACTOR);
+      expect(gap).toBeCloseTo(cellWidth * DEFAULT_INK_WIDTH_CELL_FACTOR);
     });
 
     it('preserves explicit zero advance under InkWidth strategy', () => {

--- a/src/advanceWidthStrategy.ts
+++ b/src/advanceWidthStrategy.ts
@@ -66,7 +66,7 @@ export class InkWidthAdvanceStrategy extends ShxAdvanceWidthStrategy {
   /**
    * Resolves ink-based advance for a glyph at a scaled cell width.
    *
-   * Left-origin glyphs (`minX >= 0`): `inkWidth + cellWidth * factor`.
+   * Left-origin glyphs (`minX >= 0`): `maxX + cellWidth * factor`.
    * Center-origin glyphs (`minX < 0`): advance to the right cell edge
    * (`max(maxX, cellWidth / 2)`) plus padding, so narrow centered punctuation
    * keeps trailing whitespace instead of colliding with the next glyph.
@@ -88,7 +88,7 @@ export class InkWidthAdvanceStrategy extends ShxAdvanceWidthStrategy {
       return Math.max(maxX, cellWidth / 2) + cellPadding;
     }
 
-    return InkWidthAdvanceStrategy.getInkWidth(shape) + cellPadding;
+    return maxX + cellPadding;
   }
 
   resolve(shape: ShxShape, cellWidth: number): number {

--- a/src/advanceWidthStrategy.ts
+++ b/src/advanceWidthStrategy.ts
@@ -50,12 +50,6 @@ export class InkWidthAdvanceStrategy extends ShxAdvanceWidthStrategy {
     this.cellWidthFactor = cellWidthFactor;
   }
 
-  /** Horizontal ink extent of a glyph (`bbox.maxX - bbox.minX`). */
-  static getInkWidth(shape: ShxShape): number {
-    const { minX, maxX } = shape.bbox;
-    return Math.max(0, maxX - minX);
-  }
-
   /**
    * True when ink extends left of the glyph origin (UNIFONT center-cell encoding).
    */


### PR DESCRIPTION
## Summary

- Fix `InkWidthAdvanceStrategy` for left-origin glyphs (`minX >= 0`): advance is now `maxX + cellPadding` instead of `inkWidth + cellPadding`, so glyphs whose ink starts right of the origin (e.g. aehalf `;`, `:`, `1`) keep correct trailing whitespace.
- Add regression tests for left-offset punctuation and aehalf semicolon/colon/digit-one spacing.
- Bump version to 1.4.3.

## Test plan

- [x] `npm test` — `glyphLayout.test.ts` and `textLayout.test.ts` pass, including new cases
- [x] Verified gap to the next glyph equals `cellWidth * 0.2` for left-offset punctuation
- [x] Verified aehalf `;E`, `:D`, and `10` pairs preserve expected trailing padding
