### PR TITLE
fix: detect baseline-origin UNIFONT fonts and skip capHeight shift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mlightcad/shx-parser",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A TypeScript library for parsing AutoCAD SHX font files",
   "type": "module",
   "main": "dist/index.cjs.js",

--- a/src/__tests__/font.test.ts
+++ b/src/__tests__/font.test.ts
@@ -1,4 +1,8 @@
-import { ShxFont } from '../font';
+import {
+  ShxFont,
+  detectUnifontBaselineOriginFont,
+  unifontUsesBaselineOrigin,
+} from '../font';
 import { ShxNativeAdvanceStrategy } from '../advanceWidthStrategy';
 import { alignShxGlyphForLayout, computeFontMetrics } from '../glyphLayout';
 import { ShxFontData, ShxFontType } from '../fontData';
@@ -266,6 +270,121 @@ describe('ShxFont', () => {
       } finally {
         font.release();
       }
+    });
+
+    it('skips capHeight shift for dual-orientation unifont glyphs', () => {
+      const unifontData: ShxFontData = {
+        header: { fontType: ShxFontType.UNIFONT, fileHeader: 'test', fileVersion: '1.0' },
+        content: {
+          data: { 97: new Uint8Array([0x02, 0x08, 0x00, 0x04, 0x01, 0x80, 0x02, 0x00]) },
+          info: '',
+          orientation: 'horizontal',
+          baseUp: 8,
+          baseDown: 2,
+          height: 10,
+          width: 10,
+          isExtended: false,
+          dualOrientation: true,
+        },
+      };
+      const font = new ShxFont(unifontData);
+      try {
+        const raw = font.getCharShape(97, 16)!;
+        const layout = font.getLayoutCharShape(97, 16)!;
+        expect(layout.bbox.minY).toBeCloseTo(raw.bbox.minY, 0);
+        expect(layout.bbox.maxY).toBeCloseTo(raw.bbox.maxY, 0);
+      } finally {
+        font.release();
+      }
+    });
+  });
+
+  describe('unifont baseline-origin detection', () => {
+    const topOriginUnifont: ShxFontData = {
+      header: { fontType: ShxFontType.UNIFONT, fileHeader: 'test', fileVersion: '1.0' },
+      content: {
+        data: { 48: new Uint8Array([0x01, 0x80, 0x02, 0x00]) },
+        info: '',
+        orientation: 'horizontal',
+        baseUp: 8,
+        baseDown: 2,
+        height: 10,
+        width: 10,
+        isExtended: false,
+      },
+    };
+
+    it('detects baseline-origin glyphs from ink above y = 0', () => {
+      const size = 16;
+      const metrics = computeFontMetrics(topOriginUnifont.content, size);
+      const baselineGlyph = new ShxShape(new Point(8, 0), [
+        [new Point(1, 2), new Point(6, 12)],
+      ]);
+      const topOriginGlyph = new ShxShape(new Point(8, 0), [
+        [new Point(1, -10), new Point(6, -2)],
+      ]);
+
+      expect(unifontUsesBaselineOrigin(baselineGlyph, metrics)).toBe(true);
+      expect(unifontUsesBaselineOrigin(topOriginGlyph, metrics)).toBe(false);
+    });
+
+    it('rejects baseline-origin detection for tiny ink marks', () => {
+      const size = 16;
+      const metrics = computeFontMetrics(topOriginUnifont.content, size);
+      const tinyMark = new ShxShape(new Point(8, 0), [
+        [new Point(2, 0), new Point(2, 0)],
+      ]);
+      expect(unifontUsesBaselineOrigin(tinyMark, metrics)).toBe(false);
+    });
+
+    it('returns false for non-unifont fonts', () => {
+      const fontData = createBigFontData({ 1: new Uint8Array([0x01, 0x80, 0x02, 0x00]) });
+      const size = 16;
+      const metrics = computeFontMetrics(fontData.content, size);
+      const glyph = new ShxShape(new Point(8, 0), [[new Point(1, 2), new Point(6, 12)]]);
+
+      expect(
+        detectUnifontBaselineOriginFont(fontData, () => glyph, size)
+      ).toBe(false);
+    });
+
+    it('returns true for dual-orientation unifont files', () => {
+      const fontData: ShxFontData = {
+        ...topOriginUnifont,
+        content: { ...topOriginUnifont.content, dualOrientation: true },
+      };
+      expect(
+        detectUnifontBaselineOriginFont(fontData, () => undefined, 16)
+      ).toBe(true);
+    });
+
+    it('samples available glyphs and skips missing codes', () => {
+      const size = 16;
+      const metrics = computeFontMetrics(topOriginUnifont.content, size);
+      const baselineGlyph = new ShxShape(new Point(8, 0), [
+        [new Point(1, 2), new Point(6, 12)],
+      ]);
+
+      expect(
+        detectUnifontBaselineOriginFont(
+          topOriginUnifont,
+          (code) => (code === 48 ? baselineGlyph : undefined),
+          size
+        )
+      ).toBe(true);
+
+      expect(
+        detectUnifontBaselineOriginFont(
+          {
+            ...topOriginUnifont,
+            content: { ...topOriginUnifont.content, data: {} },
+          },
+          () => baselineGlyph,
+          size
+        )
+      ).toBe(false);
+
+      expect(unifontUsesBaselineOrigin(baselineGlyph, metrics)).toBe(true);
     });
   });
 });

--- a/src/__tests__/glyphLayout.test.ts
+++ b/src/__tests__/glyphLayout.test.ts
@@ -328,12 +328,11 @@ describe('glyph layout alignment', () => {
 
     try {
       const size = 7.5;
-      const isocpMetrics = isocp.getFontMetrics(size);
       const digitLayout = isocp.getLayoutCharShape('1'.charCodeAt(0), size)!;
       const rawDigit = isocp.getCharShape('1'.charCodeAt(0), size)!;
       const hanLayout = hztxt.getLayoutCharShape(0xb5f7, size)!;
 
-      expect(digitLayout.bbox.minY).toBeCloseTo(rawDigit.bbox.minY + isocpMetrics.capHeight, 0);
+      expect(digitLayout.bbox.minY).toBeCloseTo(rawDigit.bbox.minY, 0);
       expect(hanLayout.bbox.minY).toBeCloseTo(hztxt.getCharShape(0xb5f7, size)!.bbox.minY, 0);
 
       const placed = layoutTextRun([
@@ -342,6 +341,8 @@ describe('glyph layout alignment', () => {
         { font: isocp, code: 'H'.charCodeAt(0), size },
       ]);
       expect(placed).toHaveLength(3);
+      expect(placed[0].shape.bbox.minY).toBeCloseTo(placed[1].shape.bbox.minY, 0);
+      expect(placed[2].shape.bbox.minY).toBeCloseTo(placed[1].shape.bbox.minY, 0);
       expect(placed[1].x).toBeCloseTo(
         resolveAdvanceWidth(digitLayout, isocp.fontData, size),
         0
@@ -349,6 +350,22 @@ describe('glyph layout alignment', () => {
     } finally {
       isocp.release();
       hztxt.release();
+    }
+  }, 60_000);
+
+  it('keeps isocp hyphen at mid-cell height in baseline-origin fonts', async () => {
+    const isocp = await loadFont('isocp.shx');
+    if (!isocp) return;
+
+    try {
+      const size = 7.5;
+      const digit = isocp.getLayoutCharShape('0'.charCodeAt(0), size)!;
+      const hyphen = isocp.getLayoutCharShape('-'.charCodeAt(0), size)!;
+      expect(hyphen.bbox.minY).toBeGreaterThan(digit.bbox.minY);
+      expect(hyphen.bbox.maxY).toBeLessThan(digit.bbox.maxY);
+      expect(hyphen.bbox.minY).toBeCloseTo(2.02, 0);
+    } finally {
+      isocp.release();
     }
   }, 60_000);
 });

--- a/src/font.ts
+++ b/src/font.ts
@@ -2,8 +2,13 @@ import { ShxFileReader } from './fileReader';
 import { ShxFontData } from './fontData';
 import { ShxHeaderParser } from './headerParser';
 import { ShxContentParserFactory } from './contentParser';
-import { alignShxGlyphForLayout, computeFontMetrics, ShxFontMetrics } from './glyphLayout';
 import { defaultAdvanceWidthStrategy, ShxAdvanceWidthStrategy } from './advanceWidthStrategy';
+import {
+  alignShxGlyphForLayout,
+  computeFontMetrics,
+  detectUnifontBaselineOriginFont,
+  ShxFontMetrics,
+} from './glyphLayout';
 import { ShxShapeParser } from './shapeParser';
 import { ShxShape } from './shape';
 
@@ -17,7 +22,9 @@ export {
 export {
   alignShxGlyphForLayout,
   computeFontMetrics,
+  detectUnifontBaselineOriginFont,
   shapeEncodedWithTopOrigin,
+  unifontUsesBaselineOrigin,
   type ShxFontMetrics,
 } from './glyphLayout';
 
@@ -31,6 +38,8 @@ export class ShxFont {
   public readonly fontData: ShxFontData;
   /** Parser for converting character codes to shapes */
   private readonly shapeParser: ShxShapeParser;
+  /** Cached UNIFONT baseline-origin detection (size-independent). */
+  private unifontBaselineOriginFont?: boolean;
 
   /**
    * Creates a new ShxFont instance.
@@ -136,7 +145,33 @@ export class ShxFont {
     if (!raw) {
       return undefined;
     }
-    return alignShxGlyphForLayout(raw, this.fontData, size, advanceStrategy);
+    return alignShxGlyphForLayout(
+      raw,
+      this.fontData,
+      size,
+      advanceStrategy,
+      this.usesUnifontBaselineOriginFont(size)
+    );
+  }
+
+  /**
+   * Returns whether this UNIFONT encodes horizontal glyphs with baseline at y = 0.
+   *
+   * The result is computed once via {@link detectUnifontBaselineOriginFont} and cached,
+   * because baseline-origin detection is independent of render size.
+   *
+   * @param size - Font size used when sampling glyph geometry for detection
+   * @returns True when baseline-origin UNIFONT shifting should be skipped during layout
+   */
+  private usesUnifontBaselineOriginFont(size: number): boolean {
+    if (this.unifontBaselineOriginFont === undefined) {
+      this.unifontBaselineOriginFont = detectUnifontBaselineOriginFont(
+        this.fontData,
+        (code) => this.getCharShape(code, size),
+        size
+      );
+    }
+    return this.unifontBaselineOriginFont;
   }
 
   /**

--- a/src/glyphLayout.ts
+++ b/src/glyphLayout.ts
@@ -60,11 +60,67 @@ export function shapeEncodedWithTopOrigin(
 }
 
 /**
+ * True when a UNIFONT glyph already encodes with the baseline at y = 0 and ink
+ * above it (for example isocp.shx, tssdeng.shx with dualOrientation).
+ *
+ * These fonts must not receive the capHeight shift applied to top-origin UNIFONTs.
+ */
+export function unifontUsesBaselineOrigin(
+  shape: ShxShape,
+  metrics: ShxFontMetrics
+): boolean {
+  const threshold = -(metrics.descenderHeight + metrics.capHeight * 0.05);
+  if (shape.bbox.minY < threshold) {
+    return false;
+  }
+  const inkHeight = shape.bbox.maxY - shape.bbox.minY;
+  if (inkHeight < metrics.capHeight * 0.05) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Detects whether a UNIFONT file encodes horizontal glyphs with baseline at y = 0.
+ *
+ * Samples common ASCII letter/digit codes from the font. When any sample matches
+ * {@link unifontUsesBaselineOrigin}, the whole font skips capHeight shifting so
+ * punctuation such as hyphen and tilde keep their in-cell vertical positions.
+ */
+export function detectUnifontBaselineOriginFont(
+  fontData: ShxFontData,
+  getRawShape: (code: number) => ShxShape | undefined,
+  size: number
+): boolean {
+  if (fontData.header.fontType !== ShxFontType.UNIFONT) {
+    return false;
+  }
+  if (fontData.content.dualOrientation) {
+    return true;
+  }
+  const metrics = computeFontMetrics(fontData.content, size);
+  for (const code of [48, 65, 78, 49]) {
+    if (!(code in fontData.content.data)) {
+      continue;
+    }
+    const raw = getRawShape(code);
+    if (raw && unifontUsesBaselineOrigin(raw, metrics)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Maps a glyph from font coordinates to layout coordinates using shape #0 metrics.
  *
  * UNIFONT encodes y = 0 at the cell top with negative y toward the baseline at
  * y = -baseUp. Layout uses y = 0 at the baseline with positive y upward, so glyphs
  * are shifted by {@link ShxFontMetrics.capHeight}.
+ *
+ * ISO-style UNIFONT files (isocp.shx) and dual-orientation fonts (txt.shx) already
+ * encode horizontal glyphs with baseline at y = 0; they are detected via
+ * {@link unifontUsesBaselineOrigin} and {@link ShxFontContentData.dualOrientation}.
  *
  * Some SHAPES text fonts (e.g. gdt.shx) reuse the same top-origin encoding; they are
  * detected via {@link shapeEncodedWithTopOrigin}.
@@ -75,7 +131,8 @@ function alignGlyphWithMetrics(
   shape: ShxShape,
   fontData: ShxFontData,
   metrics: ShxFontMetrics,
-  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy
+  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy,
+  unifontBaselineOriginFont = false
 ): ShxShape {
   let aligned = shape;
 
@@ -83,8 +140,14 @@ function alignGlyphWithMetrics(
     fontData.header.fontType === ShxFontType.UNIFONT ||
     shapeEncodedWithTopOrigin(fontData, shape, metrics)
   ) {
-    // Dual-orientation unifont horizontal glyphs (txt.shx) already use baseline at y = 0.
-    if (!(fontData.header.fontType === ShxFontType.UNIFONT && fontData.content.dualOrientation)) {
+    const skipUnifontCapShift =
+      fontData.header.fontType === ShxFontType.UNIFONT &&
+      (unifontBaselineOriginFont ||
+        fontData.content.dualOrientation ||
+        unifontUsesBaselineOrigin(shape, metrics));
+    const needsCapHeightShift =
+      fontData.header.fontType === ShxFontType.UNIFONT ? !skipUnifontCapShift : true;
+    if (needsCapHeightShift) {
       aligned = aligned.offset(new Point(0, metrics.capHeight), true);
     }
   }
@@ -104,14 +167,21 @@ function alignGlyphWithMetrics(
  * Applies font metrics to scaled SHX geometry for text layout.
  *
  * Raw {@link ShxFont.getCharShape} output keeps encoded coordinates from the SHX file;
- * this function repositions glyphs so mixed-font lines share a common baseline.
+ * this function repositions glyphs so mixed-font lines share a common baseline at y = 0.
  */
 export function alignShxGlyphForLayout(
   shape: ShxShape,
   fontData: ShxFontData,
   size: number,
-  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy
+  advanceStrategy: ShxAdvanceWidthStrategy = defaultAdvanceWidthStrategy,
+  unifontBaselineOriginFont = false
 ): ShxShape {
   const metrics = computeFontMetrics(fontData.content, size);
-  return alignGlyphWithMetrics(shape, fontData, metrics, advanceStrategy);
+  return alignGlyphWithMetrics(
+    shape,
+    fontData,
+    metrics,
+    advanceStrategy,
+    unifontBaselineOriginFont
+  );
 }


### PR DESCRIPTION
## Summary
- Add detection for UNIFONT files that encode horizontal glyphs with baseline at y=0 (e.g. isocp.shx, dual-orientation fonts)
- Skip the capHeight vertical shift for these fonts so punctuation like hyphen and tilde keep their in-cell positions
- Cache baseline-origin detection per font instance; bump version to 1.4.4

## Test plan
- [x] All glyphLayout tests pass (including new isocp hyphen test and updated mixed isocp/hztxt alignment test)
- [x] Full test suite passes (207 tests); one CDN fetch timeout observed under parallel load, passes in isolation
- [x] ESLint passes (2 pre-existing style warnings only)